### PR TITLE
[Feat] #16 - 유저 CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // bcrypt
+    implementation 'at.favre.lib:bcrypt:0.10.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ddukbbegi/api/user/controller/UserController.java
+++ b/src/main/java/com/ddukbbegi/api/user/controller/UserController.java
@@ -1,0 +1,91 @@
+package com.ddukbbegi.api.user.controller;
+
+import com.ddukbbegi.api.user.dto.request.*;
+import com.ddukbbegi.api.user.dto.response.MyInfoResponseDto;
+import com.ddukbbegi.api.user.dto.response.SignupResponseDto;
+import com.ddukbbegi.api.user.dto.response.UserInfoResponseDto;
+import com.ddukbbegi.api.user.service.UserService;
+import com.ddukbbegi.common.component.BaseResponse;
+import com.ddukbbegi.common.component.ResultCode;
+import com.fasterxml.jackson.databind.ser.Serializers;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    // 회원가입
+    @PostMapping("/auth/signup")
+    public BaseResponse<SignupResponseDto> createUser(@RequestBody SignupRequestDto requestDto) {
+
+        SignupResponseDto signUpResponseDto = userService.signup(requestDto);
+        return BaseResponse.success(signUpResponseDto, ResultCode.CREATED);
+    }
+
+    // 내 정보 조회
+    // 추후에 PathVariable 대신 토큰 값 이용할 예정.
+    @GetMapping("/users/me/{userId}")
+    public BaseResponse<MyInfoResponseDto> getUser(@PathVariable Long userId) {
+        MyInfoResponseDto myInfoResponseDto = userService.getUser(userId);
+
+        return BaseResponse.success(myInfoResponseDto, ResultCode.OK);
+    }
+
+    // 다른 유저 조회
+    @GetMapping("/users/{userId}")
+    public BaseResponse<UserInfoResponseDto> getUserById(@PathVariable Long userId) {
+        UserInfoResponseDto userInfoResponseDto = userService.getUserById(userId);
+
+        return BaseResponse.success(userInfoResponseDto, ResultCode.OK);
+    }
+
+    /**
+     * 추후에 PathVariable 대신 토큰 값 이용할 예정.
+     * Auth 경로인 경우 Auth 패키지에 추가할 예정 (기본적인 User Crud 만드는 것이 목적)
+     * -> 필터와 토큰 로직이 만들어질 경우 리팩토링 할 것임.
+     */
+
+    // 패스워드 변경
+    @PatchMapping("/auth/changePassword/{userId}")
+    public BaseResponse<Void> updatePassword(@PathVariable Long userId,
+                                             @RequestBody UpdatePasswordRequestDto requestDto) {
+        userService.updatePassword(userId, requestDto);
+        return BaseResponse.success(ResultCode.NO_CONTENT);
+    }
+
+    // 이메일 변경
+    @PatchMapping("/users/me/email/{userId}")
+    public BaseResponse<Void> updateEmail(@PathVariable Long userId,
+                                          @RequestBody UpdateEmailRequestDto requestDto) {
+        userService.updateEmail(userId, requestDto);
+        return BaseResponse.success(ResultCode.NO_CONTENT);
+    }
+
+    // 이름 변경
+    @PatchMapping("/users/me/name/{userId}")
+    public BaseResponse<Void> updateName(@PathVariable Long userId,
+                                         @RequestBody UpdateNameRequestDto requestDto
+    ) {
+        userService.updateName(userId, requestDto);
+        return BaseResponse.success(ResultCode.NO_CONTENT);
+    }
+
+    // 전화번호 변경
+    @PatchMapping("/users/me/phone/{userId}")
+    public BaseResponse<Void> updatePhone(@PathVariable Long userId,
+                                          @RequestBody UpdatePhoneRequestDto requestDto) {
+        userService.updatePhone(userId, requestDto);
+        return BaseResponse.success(ResultCode.NO_CONTENT);
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping("/users/{userId}")
+    public BaseResponse<Void> deleteUser(@PathVariable Long userId, @RequestBody DeleteUserRequestDto requestDto) {
+        userService.deleteUser(userId, requestDto);
+        return BaseResponse.success(ResultCode.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/request/DeleteUserRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/request/DeleteUserRequestDto.java
@@ -1,0 +1,12 @@
+package com.ddukbbegi.api.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteUserRequestDto {
+
+    private final String password;
+
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/request/SignupRequestDto.java
@@ -1,0 +1,36 @@
+package com.ddukbbegi.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @Size(max = 50)
+    private final String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다."
+    )
+    private final String password;
+
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    @Size(max = 10, message = "이름은 10자 이내로 입력해주세요.")
+    private final String name;
+
+    @NotBlank(message = "전화번호는 필수 입력값입니다.")
+    @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private final String phone;
+
+    @NotBlank(message = "권한은 필수값 입니다.")
+    private final String role;
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/request/UpdateEmailRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/request/UpdateEmailRequestDto.java
@@ -1,0 +1,16 @@
+package com.ddukbbegi.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateEmailRequestDto {
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "유효한 이메일 주소를 입력하세요.")
+    @Size(max = 50)
+    private final String email;
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/request/UpdateNameRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/request/UpdateNameRequestDto.java
@@ -1,0 +1,14 @@
+package com.ddukbbegi.api.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateNameRequestDto {
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    @Size(max = 10, message = "이름은 10자 이내로 입력해주세요.")
+    private final String name;
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/request/UpdatePasswordRequestDto.java
@@ -1,0 +1,13 @@
+package com.ddukbbegi.api.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePasswordRequestDto {
+
+    private final String oldPassword;
+
+    private final String newPassword;
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/request/UpdatePhoneRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/request/UpdatePhoneRequestDto.java
@@ -1,0 +1,14 @@
+package com.ddukbbegi.api.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePhoneRequestDto {
+    @NotBlank(message = "전화번호는 필수 입력값입니다.")
+    @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private final String phone;
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/response/MyInfoResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/response/MyInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.ddukbbegi.api.user.dto.response;
+
+import com.ddukbbegi.api.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyInfoResponseDto {
+    private final String name;
+    private final String email;
+
+    public static MyInfoResponseDto toDto(User user) {
+        return new MyInfoResponseDto(user.getName(), user.getEmail());
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/response/SignupResponseDto.java
@@ -1,0 +1,16 @@
+package com.ddukbbegi.api.user.dto.response;
+
+import com.ddukbbegi.api.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupResponseDto {
+
+    private final Long id;
+
+    public static SignupResponseDto toDto(Long id) {
+        return new SignupResponseDto(id);
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/user/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,15 @@
+package com.ddukbbegi.api.user.dto.response;
+
+import com.ddukbbegi.api.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponseDto {
+    private String name;
+
+    public static UserInfoResponseDto toDto(User user) {
+        return new UserInfoResponseDto(user.getName());
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/user/entity/User.java
+++ b/src/main/java/com/ddukbbegi/api/user/entity/User.java
@@ -1,16 +1,65 @@
 package com.ddukbbegi.api.user.entity;
 
 import com.ddukbbegi.api.common.entity.BaseTimeEntity;
+import com.ddukbbegi.api.user.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 @Table(name = "users")
+@NoArgsConstructor
 public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+
+    private boolean isDeleted = Boolean.FALSE;
+
+    public User(String email, String password, String name, String phone, UserRole userRole) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.userRole = userRole;
+    }
+
+    public static User of(String email, String password, String name, String phone, UserRole userRole) {
+        return new User(email, password, name, phone, userRole);
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void updatePhone(String phone) {
+        this.phone = phone;
+    }
 
 }

--- a/src/main/java/com/ddukbbegi/api/user/enums/UserRole.java
+++ b/src/main/java/com/ddukbbegi/api/user/enums/UserRole.java
@@ -1,0 +1,22 @@
+package com.ddukbbegi.api.user.enums;
+
+import com.ddukbbegi.common.exception.BusinessException;
+
+import java.util.Arrays;
+
+import static com.ddukbbegi.common.component.ResultCode.VALID_FAIL;
+
+/**
+ * User 권한에 대한 Enum Class
+ */
+
+public enum UserRole {
+    USER, OWNER;
+
+    public static UserRole of(String role) {
+        return Arrays.stream(UserRole.values())
+                .filter(r -> r.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(VALID_FAIL, "[USER], [OWNER] 값만 가능합니다."));
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/user/repository/UserRepository.java
+++ b/src/main/java/com/ddukbbegi/api/user/repository/UserRepository.java
@@ -4,4 +4,6 @@ import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.user.entity.User;
 
 public interface UserRepository extends BaseRepository<User, Long> {
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/ddukbbegi/api/user/service/UserService.java
+++ b/src/main/java/com/ddukbbegi/api/user/service/UserService.java
@@ -1,0 +1,36 @@
+package com.ddukbbegi.api.user.service;
+
+import com.ddukbbegi.api.user.dto.request.*;
+import com.ddukbbegi.api.user.dto.response.MyInfoResponseDto;
+import com.ddukbbegi.api.user.dto.response.SignupResponseDto;
+import com.ddukbbegi.api.user.dto.response.UserInfoResponseDto;
+import org.hibernate.sql.Update;
+
+public interface UserService {
+
+    /**
+     * 유저 회원 가입
+     * @param signUpRequestDto
+     * @return SignUpResponseDto
+     */
+    SignupResponseDto signup(SignupRequestDto signUpRequestDto);
+
+
+    /**
+     * 패스워드 변경
+     * @param requestDto
+     */
+    void updatePassword(Long userId, UpdatePasswordRequestDto requestDto);
+
+    void updateEmail(Long userId, UpdateEmailRequestDto requestDto);
+
+    void updateName(Long userId, UpdateNameRequestDto requestDto);
+
+    void updatePhone(Long userId, UpdatePhoneRequestDto requestDto);
+
+    MyInfoResponseDto getUser(Long userId);
+
+    UserInfoResponseDto getUserById(Long userId);
+
+    void deleteUser(Long userId, DeleteUserRequestDto requestDto);
+}

--- a/src/main/java/com/ddukbbegi/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/user/service/UserServiceImpl.java
@@ -1,0 +1,107 @@
+package com.ddukbbegi.api.user.service;
+
+import com.ddukbbegi.api.user.dto.request.*;
+import com.ddukbbegi.api.user.dto.response.MyInfoResponseDto;
+import com.ddukbbegi.api.user.dto.response.SignupResponseDto;
+import com.ddukbbegi.api.user.dto.response.UserInfoResponseDto;
+import com.ddukbbegi.api.user.entity.User;
+import com.ddukbbegi.api.user.enums.UserRole;
+import com.ddukbbegi.api.user.repository.UserRepository;
+import com.ddukbbegi.common.config.PasswordEncoder;
+import com.ddukbbegi.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ddukbbegi.common.component.ResultCode.AUTHENTICATION_FAILED;
+import static com.ddukbbegi.common.component.ResultCode.VALID_FAIL;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    @Override
+    public SignupResponseDto signup(SignupRequestDto signUpRequestDto) {
+
+        if (userRepository.existsByEmail(signUpRequestDto.getEmail())) {
+            throw new BusinessException(VALID_FAIL, "이미 존재하는 Email 입니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
+
+        UserRole userRole = UserRole.of(signUpRequestDto.getRole());
+
+        User user = User.of(signUpRequestDto.getEmail(), encodedPassword, signUpRequestDto.getName(), signUpRequestDto.getPhone(), userRole);
+
+        userRepository.save(user);
+
+        return SignupResponseDto.toDto(user.getId());
+    }
+
+    @Override
+    public MyInfoResponseDto getUser(Long userId) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+        return MyInfoResponseDto.toDto(findUser);
+    }
+
+    @Override
+    public UserInfoResponseDto getUserById(Long userId) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+        return UserInfoResponseDto.toDto(findUser);
+    }
+
+    @Transactional
+    @Override
+    public void updatePassword(Long userId, UpdatePasswordRequestDto requestDto) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+
+        if (!passwordEncoder.matches(requestDto.getOldPassword(), findUser.getPassword())) {
+            throw new BusinessException(AUTHENTICATION_FAILED, "비밀번호가 일치하지 않습니다.");
+        }
+
+        String newPassword = passwordEncoder.encode(requestDto.getNewPassword());
+
+        findUser.updatePassword(newPassword);
+    }
+
+    @Transactional
+    public void updateEmail(Long userId, UpdateEmailRequestDto requestDto) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+
+        if (userRepository.existsByEmail(requestDto.getEmail())) {
+            new BusinessException(VALID_FAIL, "이미 존재하는 Email 입니다.");
+        }
+
+        findUser.updateEmail(requestDto.getEmail());
+    }
+
+    @Transactional
+    public void updateName(Long userId, UpdateNameRequestDto requestDto) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+
+        findUser.updateName(requestDto.getName());
+    }
+
+    @Transactional
+    public void updatePhone(Long userId, UpdatePhoneRequestDto requestDto) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+
+        findUser.updatePhone(requestDto.getPhone());
+    }
+
+    @Override
+    public void deleteUser(Long userId, DeleteUserRequestDto requestDto) {
+        User findUser = userRepository.findByIdOrElseThrow(userId);
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(requestDto.getPassword(), findUser.getPassword())) {
+            throw new BusinessException(AUTHENTICATION_FAILED, "비밀번호가 일치하지 않습니다.");
+        }
+
+        userRepository.delete(findUser);
+    }
+}

--- a/src/main/java/com/ddukbbegi/common/config/PasswordEncoder.java
+++ b/src/main/java/com/ddukbbegi/common/config/PasswordEncoder.java
@@ -1,0 +1,16 @@
+package com.ddukbbegi.common.config;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+    public String encode(String rawPassword) {
+        return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
+    }
+
+    public boolean matches(String rawPassword, String encodedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
+        return result.verified;
+    }
+}


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: [태그] #이슈번호 - 간단한 설명
  예시: [FEAT] #12 - 로그인 API 연동
-->


## 🔎 작업 내용

- 유저의 CRUD 구현
  - 회원가입
  - 회원 조회
  - 비밀번호 변경, 이메일 변경, 이름 변경, 휴대폰번호 변경

  <br/>


## 🔧 해결해야할 문제

- 추후에 auth 경로는 인증인가 구현 후 auth 패키지 폴더로 이동할 예정.
- 일부 API 경로에서 PathVariable 로 userId를 받아아오지만, 추후에 토큰의 값으로 해결할 예정

  <br/>

<br/>
