### PR TITLE
[Feat] #23 : 가게 도메인 구현

### DIFF
--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -27,16 +27,16 @@ public class Store extends BaseUserEntity {
     private User user;
     
     @Column(nullable = false)
-    private String name;        // 가게 이름
+    private String name;
 
     @Column(nullable = false)
-    private String describe;    // 가게 소개
+    private String describe;
 
     @Column(nullable = false)
-    private Integer minDeliveryPrice;   // 최소주문금액
+    private Integer minDeliveryPrice;
 
     @Column(nullable = false)
-    private Integer deliveryTip;    // 배달팁
+    private Integer deliveryTip;
 
     @Column(nullable = false)
     @Convert(converter = DayOfWeekListConverter.class)

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -6,6 +6,7 @@ import com.ddukbbegi.api.store.enums.DayOfWeekListConverter;
 import com.ddukbbegi.api.store.enums.StoreStatus;
 import com.ddukbbegi.api.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -13,8 +14,8 @@ import java.time.LocalTime;
 import java.util.List;
 
 @Entity
-@AllArgsConstructor
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseUserEntity {
 
     @Id

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -1,9 +1,16 @@
 package com.ddukbbegi.api.store.entity;
 
 import com.ddukbbegi.api.common.entity.BaseUserEntity;
+import com.ddukbbegi.api.store.enums.DayOfWeek;
+import com.ddukbbegi.api.store.enums.DayOfWeekListConverter;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import com.ddukbbegi.api.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
 
 @Entity
 @AllArgsConstructor
@@ -11,7 +18,46 @@ import lombok.NoArgsConstructor;
 public class Store extends BaseUserEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @Column(nullable = false)
+    private String name;        // 가게 이름
+
+    @Column(nullable = false)
+    private String describe;    // 가게 소개
+
+    @Column(nullable = false)
+    private Integer minDeliveryPrice;   // 최소주문금액
+
+    @Column(nullable = false)
+    private Integer deliveryTip;    // 배달팁
+
+    @Column(nullable = false)
+    @Convert(converter = DayOfWeekListConverter.class)
+    private List<DayOfWeek> closedDays;   // 휴무일 ("SUN,MON"과 같은 형식으로 저장됨)
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StoreStatus status;     // 가게 영업 상태
+
+    // 평일 영업/휴게 시간
+    @Column(nullable = false) private LocalTime weekdayWorkingStartTime;
+    @Column(nullable = false) private LocalTime weekdayWorkingEndTime;
+    @Column(nullable = false) private LocalTime weekdayBreakStartTime;
+    @Column(nullable = false) private LocalTime weekdayBreakEndTime;
+
+    // 주말 영업/휴게 시간
+    @Column(nullable = false) private LocalTime weekendWorkingStartTime;
+    @Column(nullable = false) private LocalTime weekendWorkingEndTime;
+    @Column(nullable = false) private LocalTime weekendBreakStartTime;
+    @Column(nullable = false) private LocalTime weekendBreakEndTime;
+
+    @Column(nullable = false)
+    private boolean isPermanentlyClosed;    // 폐업 여부
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/enums/DayOfWeek.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/DayOfWeek.java
@@ -1,0 +1,5 @@
+package com.ddukbbegi.api.store.enums;
+
+public enum DayOfWeek {
+    MON, TUE, WED, THU, FRI, SAT, SUN
+}

--- a/src/main/java/com/ddukbbegi/api/store/enums/DayOfWeekListConverter.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/DayOfWeekListConverter.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Converter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,8 +22,16 @@ public class DayOfWeekListConverter implements AttributeConverter<List<DayOfWeek
     // List<DayOfWeek> -> "SUN,MON"
     @Override
     public String convertToDatabaseColumn(List<DayOfWeek> attribute) {
-        return attribute == null ? "" :
-                attribute.stream().map(Enum::name).collect(Collectors.joining(","));
+        if (attribute == null) {
+            return "";
+        }
+
+        List<DayOfWeek> sortedAttribute = attribute.stream()
+                .distinct()
+                .sorted(Comparator.comparingInt(DayOfWeek::ordinal))
+                .toList();
+
+        return sortedAttribute.stream().map(Enum::name).collect(Collectors.joining(","));
     }
     
     // DB -> Entity 로딩 시 호출

--- a/src/main/java/com/ddukbbegi/api/store/enums/DayOfWeekListConverter.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/DayOfWeekListConverter.java
@@ -1,0 +1,39 @@
+package com.ddukbbegi.api.store.enums;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 가게의 정기 휴무일 정보를 List<DayOfWeek> 형태로 관리하기 위해 사용하는 JPA AttributeConverter
+ * <p>
+ * - 자바의 List<DayOfWeek> <-> DB의 String("SUN,MON") 형태로 변환한다.
+ * - 예시) { DayOfWeek.SUN, DayOfWeek.MON } -> "MON,SUN"
+ */
+@Converter
+public class DayOfWeekListConverter implements AttributeConverter<List<DayOfWeek>, String> {
+
+    // Entity -> DB 저장 시 호출
+    // List<DayOfWeek> -> "SUN,MON"
+    @Override
+    public String convertToDatabaseColumn(List<DayOfWeek> attribute) {
+        return attribute == null ? "" :
+                attribute.stream().map(Enum::name).collect(Collectors.joining(","));
+    }
+    
+    // DB -> Entity 로딩 시 호출
+    // "SUN,MON" -> List<DayOfWeek>
+    @Override
+    public List<DayOfWeek> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.stream(dbData.split(","))
+                        .map(DayOfWeek::valueOf)
+                        .toList();
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
@@ -1,0 +1,8 @@
+package com.ddukbbegi.api.store.enums;
+
+public enum StoreStatus {
+    OPEN,                   // 정상 영업 중
+    CLOSED,                 // 영업 종료
+    TEMPORARILY_CLOSED,     // 임시 휴업 (휴게시간 포함)
+    PERMANENTLY_CLOSED      // 폐업
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 가게 도메인 entity 클래스 구현
- 휴무일 데이터는 "SUN,MON"과 같이 저장되도록 함
- 가게는 삭제 기능이 없고 대신 폐업을 설정할 수 있음 (`isPermanentlyClosed`)
  <br/>

## Ref
- #22 

This closes #23 