### PR TITLE
[Feat] #31 : JwtUtil 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
 
     // bcrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'
+
+    // jwt
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ddukbbegi/api/user/entity/User.java
+++ b/src/main/java/com/ddukbbegi/api/user/entity/User.java
@@ -27,11 +27,13 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
     private String phone;
 
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
+    @Column(nullable = false)
     private boolean isDeleted = Boolean.FALSE;
 
     public User(String email, String password, String name, String phone, UserRole userRole) {

--- a/src/main/java/com/ddukbbegi/common/config/JwtSecretGenerator.java
+++ b/src/main/java/com/ddukbbegi/common/config/JwtSecretGenerator.java
@@ -1,0 +1,13 @@
+package com.ddukbbegi.common.config;
+
+import io.jsonwebtoken.security.Keys;
+
+import java.util.Base64;
+
+public class JwtSecretGenerator {
+    public static void main(String[] args) {
+        byte[] keyBytes = Keys.secretKeyFor(io.jsonwebtoken.SignatureAlgorithm.HS256).getEncoded();
+        String base64Key = Base64.getEncoder().encodeToString(keyBytes);
+        System.out.println("jwt.secret.key: " + base64Key);
+    }
+}

--- a/src/main/java/com/ddukbbegi/common/config/JwtUtil.java
+++ b/src/main/java/com/ddukbbegi/common/config/JwtUtil.java
@@ -1,0 +1,119 @@
+package com.ddukbbegi.common.config;
+
+import com.ddukbbegi.api.user.enums.UserRole;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+    private static final Long ACCESS_TOKEN = 60 * 1000 * 5L;  // 5분
+    private static final Long REFRESH_TOKEN = 60 * 1000 * 10L; // 10 분
+
+
+    /**
+     * Access Token 발행
+     *
+     * @param userId
+     * @param email
+     * @param userRole
+     * @return
+     */
+    public String generateAccessToken(Long userId, String email, UserRole userRole) {
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .claim("email", email)
+                        .claim("userRole", userRole)
+                        .setExpiration(createExpireDate(ACCESS_TOKEN))
+                        .signWith(signatureAlgorithm, createSigningKey(secretKey))
+                        .compact();
+    }
+
+    /**
+     * Refresh Token 발행
+     *
+     * @param userId
+     * @return
+     */
+    public String generateRefreshToken(Long userId) {
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .setExpiration(createExpireDate(REFRESH_TOKEN))
+                        .signWith(signatureAlgorithm, createSigningKey(secretKey))
+                        .compact();
+    }
+
+    /**
+     * Token Valid 검증
+     *
+     * @param token
+     * @return
+     */
+    public boolean isValidToken(String token) {
+        if (token == null || token.isEmpty()) {
+            log.info("Token is Null or Empty");
+            return false;
+        }
+        try {
+            Claims claims = getClaimsFromToken(token);
+            log.info("Valid Token");
+            return true;
+        } catch (ExpiredJwtException exception) {
+            log.info("Token Expired UserID: {}", exception.getClaims().getSubject());
+            return false;
+        } catch (JwtException exception) {
+            log.warn("Token Tampered");
+            return false;
+        }
+    }
+
+    /**
+     * 토큰 정보 추출
+     *
+     * @param token
+     * @return
+     */
+    private Claims getClaimsFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(createSigningKey(secretKey))
+                .build()
+                .parseClaimsJws(token).getBody();
+    }
+
+    /**
+     * JWT 토큰의 만료 시간 생성
+     *
+     * @param expireDate : 시간 연산에 사용되는 밀리초 값 = long
+     * @return Date
+     */
+    public Date createExpireDate(Long expireDate) {
+        return new Date(System.currentTimeMillis() + expireDate);
+    }
+
+    /**
+     * JWT 서명을 위한 비밀 키 생성
+     *
+     * @param key
+     * @return
+     */
+    private Key createSigningKey(String key) {
+        return new SecretKeySpec(Base64.getDecoder().decode(key), SignatureAlgorithm.HS256.getJcaName());
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/common/config/JwtUtil.java
+++ b/src/main/java/com/ddukbbegi/common/config/JwtUtil.java
@@ -110,7 +110,7 @@ public class JwtUtil {
      * JWT 서명을 위한 비밀 키 생성
      *
      * @param key
-     * @return
+     * @return Key
      */
     private Key createSigningKey(String key) {
         return new SecretKeySpec(Base64.getDecoder().decode(key), SignatureAlgorithm.HS256.getJcaName());


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: [태그] #이슈번호 : 간단한 설명
  예시: [Feat] #12 : 로그인 API 연동
-->


## 🔎 작업 내용

- #16 User Entity `nullable` 제약 추가
- Jwt Util 생성
- gradle jwt 의존성 추가
- JwtSecretGenerator 통해서 인코딩 된 인증키를 얻을 수 있음

  <br/>

# 💡비고

- secretkey 등록

1. JwtSecretGenerator() 메서드 실행
2. 콘솔창에서 secretKey 복사
3. local.yml 에 아래와 같이 추가
```
jwt:
  secret:
    key: kLnwdX7nrb5+8fb+3dRYiORKwjBsy3dLyHX5MJh182o=
```

  <br/>

<br/>
