### PR TITLE
[Feat] #33 : Menu domain's CRUD

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+### Reference Documentation
+
+For further reference, please consider the following sections:
+
+* [Official Gradle documentation](https://docs.gradle.org)
+* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/3.4.4/gradle-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.4.4/gradle-plugin/packaging-oci-image.html)
+* [Spring Data JPA](https://docs.spring.io/spring-boot/3.4.4/reference/data/sql.html#data.sql.jpa-and-spring-data)
+* [Spring Web](https://docs.spring.io/spring-boot/3.4.4/reference/web/servlet.html)
+
+### Guides
+
+The following guides illustrate how to use some features concretely:
+
+* [Accessing Data with JPA](https://spring.io/guides/gs/accessing-data-jpa/)
+* [Accessing data with MySQL](https://spring.io/guides/gs/accessing-data-mysql/)
+* [Building a RESTful Web Service](https://spring.io/guides/gs/rest-service/)
+* [Serving Web Content with Spring MVC](https://spring.io/guides/gs/serving-web-content/)
+* [Building REST services with Spring](https://spring.io/guides/tutorials/rest/)
+
+### Additional Links
+
+These additional references should also help you:
+
+* [Gradle Build Scans – insights for your project's build](https://scans.gradle.com#gradle)
+

--- a/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
+++ b/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
@@ -1,5 +1,7 @@
 package com.ddukbbegi.api.menu.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.response.AllMenuResponseDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 import com.ddukbbegi.api.menu.service.MenuService;
 
@@ -21,6 +24,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MenuController {
 	private final MenuService menuService;
+
+	@GetMapping
+	public List<AllMenuResponseDto> findAllMenu(@PathVariable long storeId) {
+		return menuService.findAllMenuByStore(storeId);
+	}
 
 	@GetMapping("/{menuId}")
 	public DetailMenuResponseDto findDetailMenu(@PathVariable long storeId, @PathVariable long menuId) {

--- a/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
+++ b/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
@@ -17,6 +17,7 @@ import com.ddukbbegi.api.menu.dto.response.AllMenuResponseDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 import com.ddukbbegi.api.menu.service.MenuService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,28 +28,28 @@ public class MenuController {
 
 	@GetMapping
 	public List<AllMenuResponseDto> findAllMenu(@PathVariable long storeId) {
-		return menuService.findAllMenuByStore(storeId);
+		return menuService.findAllMenu(storeId);
 	}
 
 	@GetMapping("/{menuId}")
 	public DetailMenuResponseDto findDetailMenu(@PathVariable long storeId, @PathVariable long menuId) {
-		return menuService.findMenuById(storeId, menuId);
+		return menuService.findMenu(storeId, menuId);
 	}
 
 	@PostMapping
-	public Long addNewMenu(@PathVariable long storeId, @RequestBody NewMenuRequestDto dto) {
+	public Long addNewMenu(@PathVariable long storeId, @Valid @RequestBody NewMenuRequestDto dto) {
 		return menuService.addNewMenu(storeId, dto);
 	}
 
 	@PutMapping("/{menuId}")
 	public void updateMenu(@PathVariable long storeId, @PathVariable long menuId,
 		@RequestBody UpdatingMenuRequestDto dto) {
-		menuService.updateMenuById(menuId, dto);
+		menuService.updateMenu(menuId, dto);
 	}
 
 	@DeleteMapping("/{menuId}")
 	public void deleteMenu(@PathVariable long storeId, @PathVariable long menuId) {
-		menuService.deleteMenuById(menuId);
+		menuService.deleteMenu(menuId);
 	}
 
 }

--- a/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
+++ b/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
@@ -43,7 +43,7 @@ public class MenuController {
 
 	@PutMapping("/{menuId}")
 	public void updateMenu(@PathVariable long storeId, @PathVariable long menuId,
-		@RequestBody UpdatingMenuRequestDto dto) {
+		@Valid @RequestBody UpdatingMenuRequestDto dto) {
 		menuService.updateMenu(menuId, dto);
 	}
 

--- a/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
+++ b/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
@@ -24,7 +24,7 @@ public class MenuController {
 
 	@GetMapping("/{menuId}")
 	public DetailMenuResponseDto findDetailMenu(@PathVariable long storeId, @PathVariable long menuId) {
-		return menuService.findMenuById(menuId);
+		return menuService.findMenuById(storeId, menuId);
 	}
 
 	@PostMapping

--- a/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
+++ b/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
@@ -37,4 +37,10 @@ public class MenuController {
 		@RequestBody UpdatingMenuRequestDto dto) {
 		menuService.updateMenuById(menuId, dto);
 	}
+
+	@DeleteMapping("/{menuId}")
+	public void deleteMenu(@PathVariable long storeId, @PathVariable long menuId) {
+		menuService.deleteMenuById(menuId);
+	}
+
 }

--- a/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
+++ b/src/main/java/com/ddukbbegi/api/menu/controller/MenuController.java
@@ -1,13 +1,16 @@
 package com.ddukbbegi.api.menu.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 import com.ddukbbegi.api.menu.service.MenuService;
 
@@ -29,5 +32,9 @@ public class MenuController {
 		return menuService.addNewMenu(storeId, dto);
 	}
 
-
+	@PutMapping("/{menuId}")
+	public void updateMenu(@PathVariable long storeId, @PathVariable long menuId,
+		@RequestBody UpdatingMenuRequestDto dto) {
+		menuService.updateMenuById(menuId, dto);
+	}
 }

--- a/src/main/java/com/ddukbbegi/api/menu/dto/request/NewMenuRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/request/NewMenuRequestDto.java
@@ -1,29 +1,40 @@
 package com.ddukbbegi.api.menu.dto.request;
 
 import com.ddukbbegi.api.menu.entity.Menu;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-/**
- * @packageName    : com.ddukbbegi.api.menu.dto.request
- * @fileName       : CreateMenuDto
- * @author         : yong
- * @date           : 4/23/25
- * @description    :
- */
-@Getter
 @Builder
-@RequiredArgsConstructor
-public class NewMenuRequestDto {
-	private final String name;
-	private final int price;
-	private final String description;
-	private final String category;
-	private final boolean isOption;
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NewMenuRequestDto(
+	@NotBlank(message = "이름은 필수 항목입니다.")
+	@Size(max = 50, message = "이름은 50자 이내로 입력해주세요.")
+	String name,
 
-	public Menu fromDto(long storeId) {
+	@NotNull(message = "가격은 필수 항목입니다.")
+	@Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+	@Max(value = 1_000_000, message = "가격은 1,000,000원 이하로 입력해주세요.")
+	Integer price,
+
+	@Size(max = 255, message = "설명은 255자 이내로 입력해주세요.")
+	String description,
+
+	@Size(max = 100, message = "카테고리는 100자 이내로 입력해주세요.")
+	String category,
+
+	@NotNull(message = "옵션 여부는 true 또는 false로 입력해주세요.")
+	Boolean isOption
+) {
+	public Menu toEntity(long storeId) {
 		return Menu.builder()
 			.name(name)
 			.price(price)

--- a/src/main/java/com/ddukbbegi/api/menu/dto/request/UpdatingMenuRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/request/UpdatingMenuRequestDto.java
@@ -1,0 +1,13 @@
+package com.ddukbbegi.api.menu.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class UpdatingMenuRequestDto {
+	private final String name;
+	private final int price;
+	private final String description;
+	private final String category;
+}

--- a/src/main/java/com/ddukbbegi/api/menu/dto/request/UpdatingMenuRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/request/UpdatingMenuRequestDto.java
@@ -1,13 +1,30 @@
 package com.ddukbbegi.api.menu.dto.request;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.ddukbbegi.api.menu.entity.Menu;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@RequiredArgsConstructor
-@Getter
-public class UpdatingMenuRequestDto {
-	private final String name;
-	private final int price;
-	private final String description;
-	private final String category;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdatingMenuRequestDto(
+	@NotBlank(message = "이름은 필수 항목입니다.")
+	@Size(max = 50, message = "이름은 50자 이내로 입력해주세요.")
+	String name,
+
+	@NotNull(message = "가격은 필수 항목입니다.")
+	@Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+	@Max(value = 1_000_000, message = "가격은 1,000,000원 이하로 입력해주세요.")
+	Integer price,
+
+	@Size(max = 255, message = "설명은 255자 이내로 입력해주세요.")
+	String description,
+
+	@Size(max = 100, message = "카테고리는 100자 이내로 입력해주세요.")
+	String category
+) {
+
 }

--- a/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
@@ -2,16 +2,11 @@ package com.ddukbbegi.api.menu.dto.response;
 
 import com.ddukbbegi.api.menu.entity.Menu;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public class AllMenuResponseDto {
-	private final String name;
-	private final int price;
-	private final String category;
-
+public record AllMenuResponseDto(
+	String name,
+	int price,
+	String category
+) {
 	public static AllMenuResponseDto toDto(Menu menu) {
 		return new AllMenuResponseDto(menu.getName(), menu.getPrice(), menu.getCategory());
 	}

--- a/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
@@ -2,17 +2,9 @@ package com.ddukbbegi.api.menu.dto.response;
 
 import com.ddukbbegi.api.menu.entity.Menu;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-/**
- * @packageName    : com.ddukbbegi.api.menu.dto.response
- * @fileName       : AllMenuResponseDto
- * @author         : yong
- * @date           : 4/23/25
- * @description    :
- */
 @Getter
 @RequiredArgsConstructor
 public class AllMenuResponseDto {

--- a/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
@@ -1,0 +1,26 @@
+package com.ddukbbegi.api.menu.dto.response;
+
+import com.ddukbbegi.api.menu.entity.Menu;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @packageName    : com.ddukbbegi.api.menu.dto.response
+ * @fileName       : AllMenuResponseDto
+ * @author         : yong
+ * @date           : 4/23/25
+ * @description    :
+ */
+@Getter
+@RequiredArgsConstructor
+public class AllMenuResponseDto {
+	private final String name;
+	private final int price;
+	private final String category;
+
+	public static AllMenuResponseDto toDto(Menu menu) {
+		return new AllMenuResponseDto(menu.getName(), menu.getPrice(), menu.getCategory());
+	}
+}

--- a/src/main/java/com/ddukbbegi/api/menu/dto/response/DetailMenuResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/response/DetailMenuResponseDto.java
@@ -2,20 +2,13 @@ package com.ddukbbegi.api.menu.dto.response;
 
 import com.ddukbbegi.api.menu.entity.Menu;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public class DetailMenuResponseDto {
-	private final long id;
-	private final String name;
-	private final int price;
-	private final String description;
-	private final String category;
-
-	@Builder
+public record DetailMenuResponseDto(
+	long id,
+	String name,
+	int price,
+	String description,
+	String category
+) {
 	public static DetailMenuResponseDto toDto(Menu menu) {
 		return new DetailMenuResponseDto(
 			menu.getId(),

--- a/src/main/java/com/ddukbbegi/api/menu/entity/Menu.java
+++ b/src/main/java/com/ddukbbegi/api/menu/entity/Menu.java
@@ -26,6 +26,9 @@ public class Menu {
 	@Column(name = "is_option")
 	private boolean isOption;
 
+	@Column(name = "is_deleted")
+	private boolean isDeleted = false;
+
 	@Column(name = "store_id")
 	private long storeId;
 
@@ -48,5 +51,9 @@ public class Menu {
 		this.price = price;
 		this.description = description;
 		this.category = category;
+	}
+
+	public void delete() {
+		this.isDeleted = true;
 	}
 }

--- a/src/main/java/com/ddukbbegi/api/menu/entity/Menu.java
+++ b/src/main/java/com/ddukbbegi/api/menu/entity/Menu.java
@@ -8,14 +8,6 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * @packageName    : com.ddukbbegi.api.menu.entity
- * @fileName       : Menu
- * @author         : yong
- * @date           : 4/23/25
- * @description    :
- */
-
 @Entity
 @Getter
 public class Menu {
@@ -49,5 +41,12 @@ public class Menu {
 
 	public Menu() {
 
+	}
+
+	public void update(String name, int price, String description, String category) {
+		this.name = name;
+		this.price = price;
+		this.description = description;
+		this.category = category;
 	}
 }

--- a/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
@@ -1,5 +1,7 @@
 package com.ddukbbegi.api.menu.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.Query;
 
 import com.ddukbbegi.api.common.repository.BaseRepository;
@@ -8,4 +10,7 @@ import com.ddukbbegi.api.menu.entity.Menu;
 public interface MenuRepository extends BaseRepository<Menu, Long> {
 	@Query("SELECT m FROM Menu m WHERE m.storeId = :storeId AND m.id = :id AND m.isDeleted = false")
 	Menu findMenuById(long storeId, long id);
+
+	@Query("SELECT m FROM Menu m WHERE m.storeId = :storeId AND m.isDeleted = false")
+	List<Menu> findAllMenuByStore(long storeId);
 }

--- a/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
@@ -1,7 +1,11 @@
 package com.ddukbbegi.api.menu.repository;
 
+import org.springframework.data.jpa.repository.Query;
+
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.menu.entity.Menu;
 
 public interface MenuRepository extends BaseRepository<Menu, Long> {
+	@Query("SELECT m FROM Menu m WHERE m.storeId = :storeId AND m.id = :id AND m.isDeleted = false")
+	Menu findMenuById(long storeId, long id);
 }

--- a/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
@@ -8,9 +8,9 @@ import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.menu.entity.Menu;
 
 public interface MenuRepository extends BaseRepository<Menu, Long> {
-	@Query("SELECT m FROM Menu m WHERE m.storeId = :storeId AND m.id = :id AND m.isDeleted = false")
-	Menu findMenuById(long storeId, long id);
+	@Query("SELECT m FROM Menu m WHERE m.id = :id AND m.storeId = :storeId AND m.isDeleted = false")
+	Menu findMenuByIdAndStoreIdAndIsDeletedFalse(long storeId, long id);
 
 	@Query("SELECT m FROM Menu m WHERE m.storeId = :storeId AND m.isDeleted = false")
-	List<Menu> findAllMenuByStore(long storeId);
+	List<Menu> findAllMenuByStoreAndIsDeletedFalse(long storeId);
 }

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
@@ -8,13 +8,13 @@ import com.ddukbbegi.api.menu.dto.response.AllMenuResponseDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 
 public interface MenuService {
-	List<AllMenuResponseDto> findAllMenuByStore(long storeId);
+	List<AllMenuResponseDto> findAllMenu(long storeId);
 
-	DetailMenuResponseDto findMenuById(long storeId, long menuId);
+	DetailMenuResponseDto findMenu(long storeId, long menuId);
 
 	Long addNewMenu(long storeId, NewMenuRequestDto dto);
 
-	void updateMenuById(long id, UpdatingMenuRequestDto dto);
+	void updateMenu(long id, UpdatingMenuRequestDto dto);
 
-	void deleteMenuById(long menuId);
+	void deleteMenu(long menuId);
 }

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
@@ -5,7 +5,7 @@ import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 
 public interface MenuService {
-	DetailMenuResponseDto findMenuById(long menuId);
+	DetailMenuResponseDto findMenuById(long storeId, long menuId);
 
 	Long addNewMenu(long storeId, NewMenuRequestDto dto);
 

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
@@ -1,10 +1,15 @@
 package com.ddukbbegi.api.menu.service;
 
+import java.util.List;
+
 import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.response.AllMenuResponseDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 
 public interface MenuService {
+	List<AllMenuResponseDto> findAllMenuByStore(long storeId);
+
 	DetailMenuResponseDto findMenuById(long storeId, long menuId);
 
 	Long addNewMenu(long storeId, NewMenuRequestDto dto);

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
@@ -1,10 +1,13 @@
 package com.ddukbbegi.api.menu.service;
 
 import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 
 public interface MenuService {
 	DetailMenuResponseDto findMenuById(long menuId);
 
 	Long addNewMenu(long storeId, NewMenuRequestDto dto);
+
+	void updateMenuById(long id, UpdatingMenuRequestDto dto);
 }

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuService.java
@@ -10,4 +10,6 @@ public interface MenuService {
 	Long addNewMenu(long storeId, NewMenuRequestDto dto);
 
 	void updateMenuById(long id, UpdatingMenuRequestDto dto);
+
+	void deleteMenuById(long menuId);
 }

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
@@ -3,10 +3,12 @@ package com.ddukbbegi.api.menu.service;
 import org.springframework.stereotype.Service;
 
 import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 import com.ddukbbegi.api.menu.entity.Menu;
 import com.ddukbbegi.api.menu.repository.MenuRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -20,9 +22,19 @@ public class MenuServiceImpl implements MenuService{
 		return DetailMenuResponseDto.toDto(menu);
 	}
 
+
 	@Override
+	@Transactional
 	public Long addNewMenu(long storeId, NewMenuRequestDto dto) {
 		Menu menu = menuRepository.save(dto.fromDto(storeId));
 		return menu.getId();
+	}
+
+	@Override
+	@Transactional
+	public void updateMenuById(long id, UpdatingMenuRequestDto dto) {
+		Menu menu = menuRepository.findById(id).orElseThrow();
+		menu.update(dto.getName(), dto.getPrice(), dto.getDescription(), dto.getCategory());
+		DetailMenuResponseDto.toDto(menu);
 	}
 }

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
@@ -1,9 +1,14 @@
 package com.ddukbbegi.api.menu.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
 import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
 import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.response.AllMenuResponseDto;
 import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 import com.ddukbbegi.api.menu.entity.Menu;
 import com.ddukbbegi.api.menu.repository.MenuRepository;
@@ -15,6 +20,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MenuServiceImpl implements MenuService{
 	private final MenuRepository menuRepository;
+
+	@Override
+	public List<AllMenuResponseDto> findAllMenuByStore(long storeId){
+		return menuRepository.findAllMenuByStore(storeId).stream()
+			.map(menu -> AllMenuResponseDto.toDto(menu))
+			.collect(Collectors.toList());
+	}
 
 	@Override
 	public DetailMenuResponseDto findMenuById(long storeId, long id) {

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
@@ -17,11 +17,10 @@ public class MenuServiceImpl implements MenuService{
 	private final MenuRepository menuRepository;
 
 	@Override
-	public DetailMenuResponseDto findMenuById(long id) {
-		Menu menu = menuRepository.findByIdOrElseThrow(id);
+	public DetailMenuResponseDto findMenuById(long storeId, long id) {
+		Menu menu = menuRepository.findMenuById(storeId, id);
 		return DetailMenuResponseDto.toDto(menu);
 	}
-
 
 	@Override
 	@Transactional
@@ -39,7 +38,9 @@ public class MenuServiceImpl implements MenuService{
 	}
 
 	@Override
-	public void deleteMenuById(long menuId) {
-		menuRepository.deleteById(menuId);
+	@Transactional
+	public void deleteMenuById(long id) {
+		Menu menu = menuRepository.findById(id).orElseThrow();
+		menu.delete();
 	}
 }

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
@@ -39,7 +39,7 @@ public class MenuServiceImpl implements MenuService{
 	@Override
 	@Transactional
 	public Long addNewMenu(long storeId, NewMenuRequestDto dto) {
-		Menu menu = menuRepository.save(dto.fromDto(storeId));
+		Menu menu = menuRepository.save(dto.toEntity(storeId));
 		return menu.getId();
 	}
 
@@ -47,7 +47,7 @@ public class MenuServiceImpl implements MenuService{
 	@Transactional
 	public void updateMenu(long id, UpdatingMenuRequestDto dto) {
 		Menu menu = menuRepository.findById(id).orElseThrow();
-		menu.update(dto.getName(), dto.getPrice(), dto.getDescription(), dto.getCategory());
+		menu.update(dto.name(), dto.price(), dto.description(), dto.category());
 		DetailMenuResponseDto.toDto(menu);
 	}
 

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
@@ -13,7 +13,7 @@ import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
 import com.ddukbbegi.api.menu.entity.Menu;
 import com.ddukbbegi.api.menu.repository.MenuRepository;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,15 +22,17 @@ public class MenuServiceImpl implements MenuService{
 	private final MenuRepository menuRepository;
 
 	@Override
-	public List<AllMenuResponseDto> findAllMenuByStore(long storeId){
-		return menuRepository.findAllMenuByStore(storeId).stream()
+	@Transactional(readOnly = true)
+	public List<AllMenuResponseDto> findAllMenu(long storeId){
+		return menuRepository.findAllMenuByStoreAndIsDeletedFalse(storeId).stream()
 			.map(menu -> AllMenuResponseDto.toDto(menu))
 			.collect(Collectors.toList());
 	}
 
 	@Override
-	public DetailMenuResponseDto findMenuById(long storeId, long id) {
-		Menu menu = menuRepository.findMenuById(storeId, id);
+	@Transactional(readOnly = true)
+	public DetailMenuResponseDto findMenu(long storeId, long id) {
+		Menu menu = menuRepository.findMenuByIdAndStoreIdAndIsDeletedFalse(storeId, id);
 		return DetailMenuResponseDto.toDto(menu);
 	}
 
@@ -43,7 +45,7 @@ public class MenuServiceImpl implements MenuService{
 
 	@Override
 	@Transactional
-	public void updateMenuById(long id, UpdatingMenuRequestDto dto) {
+	public void updateMenu(long id, UpdatingMenuRequestDto dto) {
 		Menu menu = menuRepository.findById(id).orElseThrow();
 		menu.update(dto.getName(), dto.getPrice(), dto.getDescription(), dto.getCategory());
 		DetailMenuResponseDto.toDto(menu);
@@ -51,7 +53,7 @@ public class MenuServiceImpl implements MenuService{
 
 	@Override
 	@Transactional
-	public void deleteMenuById(long id) {
+	public void deleteMenu(long id) {
 		Menu menu = menuRepository.findById(id).orElseThrow();
 		menu.delete();
 	}

--- a/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/menu/service/MenuServiceImpl.java
@@ -37,4 +37,9 @@ public class MenuServiceImpl implements MenuService{
 		menu.update(dto.getName(), dto.getPrice(), dto.getDescription(), dto.getCategory());
 		DetailMenuResponseDto.toDto(menu);
 	}
+
+	@Override
+	public void deleteMenuById(long menuId) {
+		menuRepository.deleteById(menuId);
+	}
 }


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: [태그] #이슈번호 : 간단한 설명
  예시: [Feat] #12 : 로그인 API 연동
-->


## 🔎 작업 내용

- 가게 id로 전체 메뉴 조회 기능 구현

- 메뉴 수정 기능 구현

- 메뉴 소프트 삭제 기능 구현


  <br/>

## 🔧 해결해야할 문제

- 현재 응답으로 간단하게 값만 가져오고 있습니다. 다음 브랜치에서 리팩토링 작업하면서 이 부분을 수정할 예정입니다.

- 주 메뉴와 옵션 메뉴를 따로 조회하는 기능을 만들어야할 것 같습니다.
  <br/>

<br/>
