### PR TITLE
[Feat] #25: 가게 CRUD 구현

### DIFF
--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
@@ -9,6 +9,7 @@ import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
 import com.ddukbbegi.api.store.service.StoreService;
 import com.ddukbbegi.common.component.BaseResponse;
 import com.ddukbbegi.common.component.ResultCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -24,7 +25,7 @@ public class StoreController {
     private final StoreService storeService;
 
     @PostMapping
-    public BaseResponse<StoreIdResponseDto> registerStore(@RequestBody StoreRegisterRequestDto dto) {
+    public BaseResponse<StoreIdResponseDto> registerStore(@RequestBody @Valid StoreRegisterRequestDto dto) {
 
         StoreIdResponseDto response = storeService.registerStore(dto);
         return BaseResponse.success(response, ResultCode.CREATED);
@@ -54,7 +55,7 @@ public class StoreController {
 
     @PatchMapping("/{storeId}/basic-info")
     public BaseResponse<Void> updateStoreBasicInfo(@PathVariable Long storeId,
-                                                   @RequestBody StoreUpdateBasicInfoRequestDto dto) {
+                                                   @RequestBody @Valid StoreUpdateBasicInfoRequestDto dto) {
 
         storeService.updateStoreBasicInfo(storeId, dto);
         return BaseResponse.success(ResultCode.OK);
@@ -62,7 +63,7 @@ public class StoreController {
 
     @PatchMapping("/{storeId}/operation-info")
     public BaseResponse<Void> updateStoreOperationInfo(@PathVariable Long storeId,
-                                                       @RequestBody StoreUpdateOperationInfoRequestDto dto) {
+                                                       @RequestBody @Valid StoreUpdateOperationInfoRequestDto dto) {
 
         storeService.updateStoreOperationInfo(storeId, dto);
         return BaseResponse.success(ResultCode.OK);
@@ -70,7 +71,7 @@ public class StoreController {
 
     @PatchMapping("/{storeId}/order-settings")
     public BaseResponse<Void> updateStoreOrderSettings(@PathVariable Long storeId,
-                                                       @RequestBody StoreUpdateOrderSettingsRequestDto dto) {
+                                                       @RequestBody @Valid StoreUpdateOrderSettingsRequestDto dto) {
 
         storeService.updateStoreOrderSettings(storeId, dto);
         return BaseResponse.success(ResultCode.OK);
@@ -78,7 +79,7 @@ public class StoreController {
 
     @PatchMapping("/{storeId}/temporarily-close")
     public BaseResponse<Void> updateTemporarilyClosed(@PathVariable Long storeId,
-                                                      @RequestBody StoreUpdateStatusRequest dto) {
+                                                      @RequestBody @Valid StoreUpdateStatusRequest dto) {
 
         storeService.updateTemporarilyClosed(storeId, dto);
         return BaseResponse.success(ResultCode.OK);
@@ -86,7 +87,7 @@ public class StoreController {
 
     @PatchMapping("/{storeId}/permanently-close")
     public BaseResponse<Void> updatePermanentlyClosed(@PathVariable Long storeId,
-                                                      @RequestBody StoreUpdateStatusRequest dto) {
+                                                      @RequestBody @Valid StoreUpdateStatusRequest dto) {
 
         storeService.updatePermanentlyClosed(storeId, dto);
         return BaseResponse.success(ResultCode.OK);

--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
@@ -23,20 +23,72 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    @GetMapping("/")
-    public BaseResponse<?> success() {
     @PostMapping
     public BaseResponse<StoreIdResponseDto> registerStore(@RequestBody StoreRegisterRequestDto dto) {
 
         StoreIdResponseDto response = storeService.registerStore(dto);
         return BaseResponse.success(response, ResultCode.CREATED);
     }
+
+    @GetMapping("/me/available")
+    public BaseResponse<StoreRegisterAvailableResponseDto> checkStoreRegistrationAvailability() {
+
+        StoreRegisterAvailableResponseDto response = storeService.checkStoreRegistrationAvailability();
+        return BaseResponse.success(response, ResultCode.OK);
+    }
+
+    @GetMapping("/me")
+    public BaseResponse<List<OwnerStoreResponseDto>> getOwnerStoreList() {
+
+        List<OwnerStoreResponseDto> response = storeService.getOwnerStoreList();
+        return BaseResponse.success(response, ResultCode.OK);
+    }
+
+    @GetMapping
+    public BaseResponse<PageResponseDto<StorePageItemResponseDto>> getStores(@RequestParam(defaultValue = "") String name,
+                                                                             @PageableDefault Pageable pageable) {
+
+        PageResponseDto<StorePageItemResponseDto> response = storeService.getStores(name, pageable);
+        return BaseResponse.success(response, ResultCode.OK);
+    }
+
+    @PatchMapping("/{storeId}/basic-info")
+    public BaseResponse<Void> updateStoreBasicInfo(@PathVariable Long storeId,
+                                                   @RequestBody StoreUpdateBasicInfoRequestDto dto) {
+
+        storeService.updateStoreBasicInfo(storeId, dto);
         return BaseResponse.success(ResultCode.OK);
     }
 
-    @GetMapping("/fail")
-    public BaseResponse<?> fail() {
-        storeService.get();
+    @PatchMapping("/{storeId}/operation-info")
+    public BaseResponse<Void> updateStoreOperationInfo(@PathVariable Long storeId,
+                                                       @RequestBody StoreUpdateOperationInfoRequestDto dto) {
+
+        storeService.updateStoreOperationInfo(storeId, dto);
+        return BaseResponse.success(ResultCode.OK);
+    }
+
+    @PatchMapping("/{storeId}/order-settings")
+    public BaseResponse<Void> updateStoreOrderSettings(@PathVariable Long storeId,
+                                                       @RequestBody StoreUpdateOrderSettingsRequestDto dto) {
+
+        storeService.updateStoreOrderSettings(storeId, dto);
+        return BaseResponse.success(ResultCode.OK);
+    }
+
+    @PatchMapping("/{storeId}/temporarily-close")
+    public BaseResponse<Void> updateTemporarilyClosed(@PathVariable Long storeId,
+                                                      @RequestBody StoreUpdateStatusRequest dto) {
+
+        storeService.updateTemporarilyClosed(storeId, dto);
+        return BaseResponse.success(ResultCode.OK);
+    }
+
+    @PatchMapping("/{storeId}/permanently-close")
+    public BaseResponse<Void> updatePermanentlyClosed(@PathVariable Long storeId,
+                                                      @RequestBody StoreUpdateStatusRequest dto) {
+
+        storeService.updatePermanentlyClosed(storeId, dto);
         return BaseResponse.success(ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
@@ -1,20 +1,36 @@
 package com.ddukbbegi.api.store.controller;
 
+import com.ddukbbegi.api.common.dto.PageResponseDto;
+import com.ddukbbegi.api.store.dto.request.*;
+import com.ddukbbegi.api.store.dto.response.OwnerStoreResponseDto;
+import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
+import com.ddukbbegi.api.store.dto.response.StoreRegisterAvailableResponseDto;
+import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
 import com.ddukbbegi.api.store.service.StoreService;
 import com.ddukbbegi.common.component.BaseResponse;
 import com.ddukbbegi.common.component.ResultCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/stores")
 public class StoreController {
 
     private final StoreService storeService;
 
     @GetMapping("/")
     public BaseResponse<?> success() {
+    @PostMapping
+    public BaseResponse<StoreIdResponseDto> registerStore(@RequestBody StoreRegisterRequestDto dto) {
+
+        StoreIdResponseDto response = storeService.registerStore(dto);
+        return BaseResponse.success(response, ResultCode.CREATED);
+    }
         return BaseResponse.success(ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreBasicInfoDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreBasicInfoDto.java
@@ -1,0 +1,34 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import com.ddukbbegi.api.store.enums.StoreCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreBasicInfoDto {
+
+    @NotBlank
+    @Size(min = 1, max = 20)
+    private String name;
+
+    private String category;
+
+    @Pattern(
+            regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
+            message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678 또는 02-123-4567"
+    )
+    private String phoneNumber;
+
+    @NotBlank(message = "가게 설명을 입력해주세요.")
+    @Size(max = 1000, message = "설명은 최대 1000자까지 입력할 수 있습니다.")
+    private String description;
+
+    public StoreCategory getCategory() {
+        return StoreCategory.fromString(this.category);
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreOperationInfoDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreOperationInfoDto.java
@@ -1,0 +1,61 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import com.ddukbbegi.api.store.enums.DayOfWeek;
+import com.ddukbbegi.api.store.util.TimeRangeParser;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class StoreOperationInfoDto {
+
+    @Pattern(
+            regexp = "^(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
+            message = "정기 휴무일 형식이 올바르지 않습니다. 예: SUN,MON"
+    )
+    private String closedDays;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekdayWorkingTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekdayBreakTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekendWorkingTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekendBreakTime;
+
+    /**
+     * 내부 파싱 로직을 통해 Entity 빌더에서 사용하기 좋은 자료형으로 변환
+     */
+    public ParsedOperationInfo toParsedData() {
+        return new ParsedOperationInfo(
+                Arrays.stream(closedDays.split(","))
+                        .map(DayOfWeek::valueOf)
+                        .toList(),
+                TimeRangeParser.parse(weekdayWorkingTime),
+                TimeRangeParser.parse(weekdayBreakTime),
+                TimeRangeParser.parse(weekendWorkingTime),
+                TimeRangeParser.parse(weekendBreakTime)
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ParsedOperationInfo {
+        private List<DayOfWeek> closedDays;
+        private Pair<LocalTime, LocalTime> weekdayWorkingTime;
+        private Pair<LocalTime, LocalTime> weekdayBreakTime;
+        private Pair<LocalTime, LocalTime> weekendWorkingTime;
+        private Pair<LocalTime, LocalTime> weekendBreakTime;
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreOrderSettingsInfo.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreOrderSettingsInfo.java
@@ -1,0 +1,20 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreOrderSettingsInfo {
+
+    @NotNull(message = "최소 배달 금액은 필수입니다.")
+    @Min(value = 0, message = "최소 배달 금액은 0원 이상이어야 합니다.")
+    private Integer minDeliveryPrice;
+
+    @NotNull(message = "배달 팁은 필수입니다.")
+    @Min(value = 0, message = "배달 팁은 0원 이상이어야 합니다.")
+    private Integer deliveryTip;
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreRegisterRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreRegisterRequestDto.java
@@ -1,4 +1,96 @@
 package com.ddukbbegi.api.store.dto.request;
 
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.DayOfWeek;
+import com.ddukbbegi.api.store.enums.StoreCategory;
+import com.ddukbbegi.api.store.util.TimeRangeParser;
+import com.ddukbbegi.api.user.entity.User;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
 public class StoreRegisterRequestDto {
+
+    @NotBlank
+    @Size(min = 1, max = 20)
+    private String name;
+
+    private String category;
+
+    @Pattern(
+            regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
+            message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678 또는 02-123-4567"
+    )
+    private String phoneNumber;
+
+    @NotBlank(message = "가게 설명을 입력해주세요.")
+    @Size(max = 1000, message = "설명은 최대 1000자까지 입력할 수 있습니다.")
+    private String description;
+
+    @Pattern(
+            regexp = "^(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
+            message = "정기 휴무일 형식이 올바르지 않습니다. 예: SUN,MON"
+    )
+    private String closedDays;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekdayWorkingTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekdayBreakTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekendWorkingTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekendBreakTime;
+
+    @NotNull(message = "최소 배달 금액은 필수입니다.")
+    @Min(value = 0, message = "최소 배달 금액은 0원 이상이어야 합니다.")
+    private Integer minDeliveryPrice;
+
+    @NotNull(message = "배달 팁은 필수입니다.")
+    @Min(value = 0, message = "배달 팁은 0원 이상이어야 합니다.")
+    private Integer deliveryTip;
+
+    public Store toEntity(User user) {
+
+        List<DayOfWeek> closedDaysList = Arrays.stream(this.closedDays.split(","))
+                .map(DayOfWeek::valueOf)
+                .toList();
+
+        Pair<LocalTime, LocalTime> weekdayWorkingTime = TimeRangeParser.parse(this.weekdayWorkingTime);
+        Pair<LocalTime, LocalTime> weekdayBreakTime = TimeRangeParser.parse(this.weekdayBreakTime);
+        Pair<LocalTime, LocalTime> weekendWorkingTime = TimeRangeParser.parse(this.weekendWorkingTime);
+        Pair<LocalTime, LocalTime> weekendBreakTime = TimeRangeParser.parse(this.weekendBreakTime);
+
+        return Store.builder()
+                .user(user)
+                .name(name)
+                .category(StoreCategory.fromString(category))
+                .phoneNumber(phoneNumber)
+                .description(description)
+                .minDeliveryPrice(minDeliveryPrice)
+                .deliveryTip(deliveryTip)
+                .closedDays(closedDaysList)
+
+                .weekdayWorkingStartTime(weekdayWorkingTime.getFirst())
+                .weekdayWorkingEndTime(weekdayWorkingTime.getSecond())
+                .weekdayBreakStartTime(weekdayBreakTime.getFirst())
+                .weekdayBreakEndTime(weekdayBreakTime.getSecond())
+                .weekendWorkingStartTime(weekendWorkingTime.getFirst())
+                .weekendWorkingEndTime(weekendWorkingTime.getSecond())
+                .weekendBreakStartTime(weekendBreakTime.getFirst())
+                .weekendBreakEndTime(weekendBreakTime.getSecond())
+
+                .build();
+    }
+
 }

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreRegisterRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreRegisterRequestDto.java
@@ -1,86 +1,44 @@
 package com.ddukbbegi.api.store.dto.request;
 
 import com.ddukbbegi.api.store.entity.Store;
-import com.ddukbbegi.api.store.enums.DayOfWeek;
-import com.ddukbbegi.api.store.enums.StoreCategory;
-import com.ddukbbegi.api.store.util.TimeRangeParser;
 import com.ddukbbegi.api.user.entity.User;
-import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.util.Pair;
 
 import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class StoreRegisterRequestDto {
 
-    @NotBlank
-    @Size(min = 1, max = 20)
-    private String name;
+    @Valid
+    private StoreBasicInfoDto basicInfoDto;
 
-    private String category;
+    @Valid
+    private StoreOperationInfoDto operationInfo;
 
-    @Pattern(
-            regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
-            message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678 또는 02-123-4567"
-    )
-    private String phoneNumber;
-
-    @NotBlank(message = "가게 설명을 입력해주세요.")
-    @Size(max = 1000, message = "설명은 최대 1000자까지 입력할 수 있습니다.")
-    private String description;
-
-    @Pattern(
-            regexp = "^(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
-            message = "정기 휴무일 형식이 올바르지 않습니다. 예: SUN,MON"
-    )
-    private String closedDays;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekdayWorkingTime;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekdayBreakTime;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekendWorkingTime;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekendBreakTime;
-
-    @NotNull(message = "최소 배달 금액은 필수입니다.")
-    @Min(value = 0, message = "최소 배달 금액은 0원 이상이어야 합니다.")
-    private Integer minDeliveryPrice;
-
-    @NotNull(message = "배달 팁은 필수입니다.")
-    @Min(value = 0, message = "배달 팁은 0원 이상이어야 합니다.")
-    private Integer deliveryTip;
+    @Valid
+    private StoreOrderSettingsInfo orderSettingsInfo;
 
     public Store toEntity(User user) {
 
-        List<DayOfWeek> closedDaysList = Arrays.stream(this.closedDays.split(","))
-                .map(DayOfWeek::valueOf)
-                .toList();
+        StoreOperationInfoDto.ParsedOperationInfo parsedOperationInfo = operationInfo.toParsedData();
 
-        Pair<LocalTime, LocalTime> weekdayWorkingTime = TimeRangeParser.parse(this.weekdayWorkingTime);
-        Pair<LocalTime, LocalTime> weekdayBreakTime = TimeRangeParser.parse(this.weekdayBreakTime);
-        Pair<LocalTime, LocalTime> weekendWorkingTime = TimeRangeParser.parse(this.weekendWorkingTime);
-        Pair<LocalTime, LocalTime> weekendBreakTime = TimeRangeParser.parse(this.weekendBreakTime);
+        Pair<LocalTime, LocalTime> weekdayWorkingTime = parsedOperationInfo.getWeekdayWorkingTime();
+        Pair<LocalTime, LocalTime> weekdayBreakTime = parsedOperationInfo.getWeekdayBreakTime();
+        Pair<LocalTime, LocalTime> weekendWorkingTime = parsedOperationInfo.getWeekendWorkingTime();
+        Pair<LocalTime, LocalTime> weekendBreakTime = parsedOperationInfo.getWeekendBreakTime();
 
         return Store.builder()
                 .user(user)
-                .name(name)
-                .category(StoreCategory.fromString(category))
-                .phoneNumber(phoneNumber)
-                .description(description)
-                .minDeliveryPrice(minDeliveryPrice)
-                .deliveryTip(deliveryTip)
-                .closedDays(closedDaysList)
+                .name(basicInfoDto.getName())
+                .category(basicInfoDto.getCategory())
+                .phoneNumber(basicInfoDto.getPhoneNumber())
+                .description(basicInfoDto.getDescription())
 
+                .closedDays(parsedOperationInfo.getClosedDays())
                 .weekdayWorkingStartTime(weekdayWorkingTime.getFirst())
                 .weekdayWorkingEndTime(weekdayWorkingTime.getSecond())
                 .weekdayBreakStartTime(weekdayBreakTime.getFirst())
@@ -89,6 +47,9 @@ public class StoreRegisterRequestDto {
                 .weekendWorkingEndTime(weekendWorkingTime.getSecond())
                 .weekendBreakStartTime(weekendBreakTime.getFirst())
                 .weekendBreakEndTime(weekendBreakTime.getSecond())
+
+                .minDeliveryPrice(orderSettingsInfo.getMinDeliveryPrice())
+                .deliveryTip(orderSettingsInfo.getDeliveryTip())
 
                 .build();
     }

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateBasicInfoRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateBasicInfoRequestDto.java
@@ -1,0 +1,29 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreUpdateBasicInfoRequestDto {
+
+    @NotBlank
+    @Size(min = 1, max = 20)
+    private String name;
+
+    private String category;
+
+    @Pattern(
+            regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
+            message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678 또는 02-123-4567"
+    )
+    private String phoneNumber;
+
+    @NotBlank(message = "가게 설명을 입력해주세요.")
+    @Size(max = 1000, message = "설명은 최대 1000자까지 입력할 수 있습니다.")
+    private String description;
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateBasicInfoRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateBasicInfoRequestDto.java
@@ -1,8 +1,6 @@
 package com.ddukbbegi.api.store.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,20 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class StoreUpdateBasicInfoRequestDto {
 
-    @NotBlank
-    @Size(min = 1, max = 20)
-    private String name;
-
-    private String category;
-
-    @Pattern(
-            regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
-            message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678 또는 02-123-4567"
-    )
-    private String phoneNumber;
-
-    @NotBlank(message = "가게 설명을 입력해주세요.")
-    @Size(max = 1000, message = "설명은 최대 1000자까지 입력할 수 있습니다.")
-    private String description;
+    @Valid
+    private StoreBasicInfoDto basicInfoDto;
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOperationInfoRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOperationInfoRequestDto.java
@@ -1,0 +1,29 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreUpdateOperationInfoRequestDto {
+
+    @Pattern(
+            regexp = "^(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
+            message = "정기 휴무일 형식이 올바르지 않습니다. 예: SUN,MON"
+    )
+    private String closedDays;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekdayWorkingTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekdayBreakTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekendWorkingTime;
+
+    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
+    private String weekendBreakTime;
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOperationInfoRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOperationInfoRequestDto.java
@@ -1,6 +1,6 @@
 package com.ddukbbegi.api.store.dto.request;
 
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,22 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class StoreUpdateOperationInfoRequestDto {
 
-    @Pattern(
-            regexp = "^(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
-            message = "정기 휴무일 형식이 올바르지 않습니다. 예: SUN,MON"
-    )
-    private String closedDays;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekdayWorkingTime;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekdayBreakTime;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekendWorkingTime;
-
-    @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.")
-    private String weekendBreakTime;
+    @Valid
+    private StoreOperationInfoDto operationInfo;
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOrderSettingsRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOrderSettingsRequestDto.java
@@ -1,0 +1,20 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreUpdateOrderSettingsRequestDto {
+
+    @NotNull(message = "최소 배달 금액은 필수입니다.")
+    @Min(value = 0, message = "최소 배달 금액은 0원 이상이어야 합니다.")
+    private Integer minDeliveryPrice;
+
+    @NotNull(message = "배달 팁은 필수입니다.")
+    @Min(value = 0, message = "배달 팁은 0원 이상이어야 합니다.")
+    private Integer deliveryTip;
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOrderSettingsRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateOrderSettingsRequestDto.java
@@ -1,7 +1,6 @@
 package com.ddukbbegi.api.store.dto.request;
 
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,12 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class StoreUpdateOrderSettingsRequestDto {
 
-    @NotNull(message = "최소 배달 금액은 필수입니다.")
-    @Min(value = 0, message = "최소 배달 금액은 0원 이상이어야 합니다.")
-    private Integer minDeliveryPrice;
-
-    @NotNull(message = "배달 팁은 필수입니다.")
-    @Min(value = 0, message = "배달 팁은 0원 이상이어야 합니다.")
-    private Integer deliveryTip;
+    @Valid
+    private StoreOrderSettingsInfo orderSettingsInfo;
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateStatusRequest.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreUpdateStatusRequest.java
@@ -1,0 +1,14 @@
+package com.ddukbbegi.api.store.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreUpdateStatusRequest {
+
+    @NotNull
+    private boolean status;
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreResponseDto.java
@@ -1,0 +1,30 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OwnerStoreResponseDto {
+
+    private Long storeId;
+    private String name;
+    private String category;
+    private StoreStatus status;
+    private boolean isTemporarilyClosed;
+    private boolean isPermanentlyClosed;
+
+    public static OwnerStoreResponseDto fromEntity(Store store) {
+        return new OwnerStoreResponseDto(
+                store.getId(),
+                store.getName(),
+                store.getCategory().name(),
+                StoreStatus.OPEN,   // TODO: status 연산 로직 필요
+                store.isTemporarilyClosed(),
+                store.isPermanentlyClosed()
+        );
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreIdResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreIdResponseDto.java
@@ -1,0 +1,16 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreIdResponseDto {
+
+    private Long storeId;
+
+    public static StoreIdResponseDto of(Long id) {
+        return new StoreIdResponseDto(id);
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StorePageItemResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StorePageItemResponseDto.java
@@ -1,0 +1,28 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StorePageItemResponseDto {
+
+    private String name;
+    private String description;
+    private String storeCategory;
+    private Integer minDeliveryPrice;
+    private Integer deliveryTip;
+
+    public static StorePageItemResponseDto fromEntity(Store store) {
+
+        return new StorePageItemResponseDto(
+                store.getName(),
+                store.getDescription(),
+                store.getCategory().name(),
+                store.getMinDeliveryPrice(),
+                store.getDeliveryTip()
+        );
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreRegisterAvailableResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreRegisterAvailableResponseDto.java
@@ -1,0 +1,15 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreRegisterAvailableResponseDto {
+
+    private boolean isAvailable;
+
+    public static StoreRegisterAvailableResponseDto of(boolean isAvailable) {
+        return new StoreRegisterAvailableResponseDto(isAvailable);
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreResponseDto.java
@@ -1,4 +1,0 @@
-package com.ddukbbegi.api.store.dto.response;
-
-public class StoreResponseDto {
-}

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -12,6 +12,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 @Entity
+@Table(name = "stores")
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -6,14 +6,16 @@ import com.ddukbbegi.api.store.enums.DayOfWeekListConverter;
 import com.ddukbbegi.api.store.enums.StoreStatus;
 import com.ddukbbegi.api.user.entity.User;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
 import java.util.List;
 
-@Entity
 @Getter
-@Builder
+@Entity
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseUserEntity {
@@ -30,6 +32,12 @@ public class Store extends BaseUserEntity {
     private String name;
 
     @Column(nullable = false)
+    private String category;    // 추후 enum 타입으로 변경될 수 있음
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
     private String describe;
 
     @Column(nullable = false)
@@ -41,10 +49,6 @@ public class Store extends BaseUserEntity {
     @Column(nullable = false)
     @Convert(converter = DayOfWeekListConverter.class)
     private List<DayOfWeek> closedDays;   // 휴무일 ("SUN,MON"과 같은 형식으로 저장됨)
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private StoreStatus status;     // 가게 영업 상태
 
     // 평일 영업/휴게 시간
     @Column(nullable = false) private LocalTime weekdayWorkingStartTime;
@@ -59,6 +63,12 @@ public class Store extends BaseUserEntity {
     @Column(nullable = false) private LocalTime weekendBreakEndTime;
 
     @Column(nullable = false)
-    private boolean isPermanentlyClosed;    // 폐업 여부
+    @Enumerated(EnumType.STRING)
+    private StoreStatus status = StoreStatus.CLOSED;     // 가게 영업 상태
+
+    @Column(nullable = false)
+    private boolean isPermanentlyClosed = false;    // 폐업 여부
+
+
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -3,19 +3,16 @@ package com.ddukbbegi.api.store.entity;
 import com.ddukbbegi.api.common.entity.BaseUserEntity;
 import com.ddukbbegi.api.store.enums.DayOfWeek;
 import com.ddukbbegi.api.store.enums.DayOfWeekListConverter;
-import com.ddukbbegi.api.store.enums.StoreStatus;
+import com.ddukbbegi.api.store.enums.StoreCategory;
 import com.ddukbbegi.api.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalTime;
 import java.util.List;
 
-@Getter
 @Entity
+@Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseUserEntity {
@@ -32,19 +29,14 @@ public class Store extends BaseUserEntity {
     private String name;
 
     @Column(nullable = false)
-    private String category;    // 추후 enum 타입으로 변경될 수 있음
+    @Enumerated(EnumType.STRING)
+    private StoreCategory category;
 
     @Column(nullable = false)
     private String phoneNumber;
 
     @Column(nullable = false)
-    private String describe;
-
-    @Column(nullable = false)
-    private Integer minDeliveryPrice;
-
-    @Column(nullable = false)
-    private Integer deliveryTip;
+    private String description;
 
     @Column(nullable = false)
     @Convert(converter = DayOfWeekListConverter.class)
@@ -63,12 +55,91 @@ public class Store extends BaseUserEntity {
     @Column(nullable = false) private LocalTime weekendBreakEndTime;
 
     @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private StoreStatus status = StoreStatus.CLOSED;     // 가게 영업 상태
+    private Integer minDeliveryPrice;
+
+    @Column(nullable = false)
+    private Integer deliveryTip;
+
+    @Column(nullable = false)
+    private boolean isTemporarilyClosed = false;
 
     @Column(nullable = false)
     private boolean isPermanentlyClosed = false;    // 폐업 여부
 
+    @Builder
+    public Store(User user,
+                 String name,
+                 StoreCategory category,
+                 String phoneNumber,
+                 String description,
+                 List<DayOfWeek> closedDays,
+                 LocalTime weekdayWorkingStartTime,
+                 LocalTime weekdayWorkingEndTime,
+                 LocalTime weekdayBreakStartTime,
+                 LocalTime weekdayBreakEndTime,
+                 LocalTime weekendWorkingStartTime,
+                 LocalTime weekendWorkingEndTime,
+                 LocalTime weekendBreakStartTime,
+                 LocalTime weekendBreakEndTime,
+                 Integer minDeliveryPrice,
+                 Integer deliveryTip) {
+        this.user = user;
+        this.name = name;
+        this.category = category;
+        this.phoneNumber = phoneNumber;
+        this.description = description;
+        this.closedDays = closedDays;
+        this.weekdayWorkingStartTime = weekdayWorkingStartTime;
+        this.weekdayWorkingEndTime = weekdayWorkingEndTime;
+        this.weekdayBreakStartTime = weekdayBreakStartTime;
+        this.weekdayBreakEndTime = weekdayBreakEndTime;
+        this.weekendWorkingStartTime = weekendWorkingStartTime;
+        this.weekendWorkingEndTime = weekendWorkingEndTime;
+        this.weekendBreakStartTime = weekendBreakStartTime;
+        this.weekendBreakEndTime = weekendBreakEndTime;
+        this.minDeliveryPrice = minDeliveryPrice;
+        this.deliveryTip = deliveryTip;
+    }
 
+    public void updateBasicInfo(String name,
+                                StoreCategory category,
+                                String phoneNumber,
+                                String description) {
+        this.name = name;
+        this.category = category;
+        this.phoneNumber = phoneNumber;
+        this.description = description;
+    }
+
+    public void updateOperationInfo(LocalTime weekdayWorkingStartTime,
+                                    LocalTime weekdayWorkingEndTime,
+                                    LocalTime weekdayBreakStartTime,
+                                    LocalTime weekdayBreakEndTime,
+                                    LocalTime weekendWorkingStartTime,
+                                    LocalTime weekendWorkingEndTime,
+                                    LocalTime weekendBreakStartTime,
+                                    LocalTime weekendBreakEndTime) {
+        this.weekdayWorkingStartTime = weekdayWorkingStartTime;
+        this.weekdayWorkingEndTime = weekdayWorkingEndTime;
+        this.weekdayBreakStartTime = weekdayBreakStartTime;
+        this.weekdayBreakEndTime = weekdayBreakEndTime;
+        this.weekendWorkingStartTime = weekendWorkingStartTime;
+        this.weekendWorkingEndTime = weekendWorkingEndTime;
+        this.weekendBreakStartTime = weekendBreakStartTime;
+        this.weekendBreakEndTime = weekendBreakEndTime;
+    }
+
+    public void updateOrderSettings(Integer minDeliveryPrice, Integer deliveryTip) {
+        this.minDeliveryPrice = minDeliveryPrice;
+        this.deliveryTip = deliveryTip;
+    }
+
+    public void updateTemporarilyClosed(boolean status) {
+        this.isTemporarilyClosed = status;
+    }
+
+    public void updatePermanentlyClosed(boolean status) {
+        this.isPermanentlyClosed = status;
+    }
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -111,7 +111,8 @@ public class Store extends BaseUserEntity {
         this.description = description;
     }
 
-    public void updateOperationInfo(LocalTime weekdayWorkingStartTime,
+    public void updateOperationInfo(List<DayOfWeek> closedDays,
+                                    LocalTime weekdayWorkingStartTime,
                                     LocalTime weekdayWorkingEndTime,
                                     LocalTime weekdayBreakStartTime,
                                     LocalTime weekdayBreakEndTime,
@@ -119,6 +120,7 @@ public class Store extends BaseUserEntity {
                                     LocalTime weekendWorkingEndTime,
                                     LocalTime weekendBreakStartTime,
                                     LocalTime weekendBreakEndTime) {
+        this.closedDays = closedDays;
         this.weekdayWorkingStartTime = weekdayWorkingStartTime;
         this.weekdayWorkingEndTime = weekdayWorkingEndTime;
         this.weekdayBreakStartTime = weekdayBreakStartTime;

--- a/src/main/java/com/ddukbbegi/api/store/enums/StoreCategory.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/StoreCategory.java
@@ -1,0 +1,41 @@
+package com.ddukbbegi.api.store.enums;
+
+import com.ddukbbegi.common.component.ResultCode;
+import com.ddukbbegi.common.exception.BusinessException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum StoreCategory {
+
+    KOREAN("한식"),
+    CHINESE("중식"),
+    JAPANESE("일식"),
+    WESTERN("양식"),
+    CHICKEN("치킨"),
+    PIZZA("피자"),
+    BURGER("버거"),
+    SNACK("분식"),
+    CAFE("카페/디저트"),
+    LATE_NIGHT("야식"),
+    BENTO("도시락/죽"),
+    ASIAN("아시안"),
+    MEAT("고기/구이"),
+    FUSION("퓨전"),
+    ETC("기타");
+
+    private final String category;
+
+    StoreCategory(String category) {
+        this.category = category;
+    }
+
+    public static StoreCategory fromString(String name) {
+        return Arrays.stream(values())
+                .filter(c -> c.category.equals(name))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ResultCode.VALID_FAIL, "존재하지 않는 카테고리명: " + name));
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
@@ -1,8 +1,20 @@
 package com.ddukbbegi.api.store.enums;
 
+import com.ddukbbegi.common.component.ResultCode;
+import com.ddukbbegi.common.exception.BusinessException;
+
 public enum StoreStatus {
     OPEN,                   // 정상 영업 중
     CLOSED,                 // 영업 종료
-    TEMPORARILY_CLOSED,     // 임시 휴업 (휴게시간 포함)
-    PERMANENTLY_CLOSED      // 폐업
+    BREAK,                  // 휴게 시간
+    TEMPORARILY_CLOSED,     // 임시 휴업
+    PERMANENTLY_CLOSED;     // 폐업
+
+    public static StoreStatus fromString(String name) {
+        try {
+            return StoreStatus.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ResultCode.VALID_FAIL, "존재하지 않는 상태명: " + name);
+        }
+    }
 }

--- a/src/main/java/com/ddukbbegi/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/ddukbbegi/api/store/repository/StoreRepository.java
@@ -2,7 +2,22 @@ package com.ddukbbegi.api.store.repository;
 
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.store.entity.Store;
-import com.ddukbbegi.api.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface StoreRepository extends BaseRepository<Store, Long> {
+
+    List<Store> findAllByUser_Id(Long userId);
+
+    @EntityGraph(attributePaths = { "user" })
+    @Query("SELECT s FROM Store s WHERE s.name LIKE :name AND s.status = 'OPEN'")
+    Page<Store> findAllOpenedStoreByName(String name, Pageable pageable);
+
+    @Query("SELECT COUNT(*) < 3 FROM Store s WHERE s.user.id = :userId AND s.isPermanentlyClosed IS FALSE")
+    boolean isStoreRegistrationAvailable(Long userId);
+
 }

--- a/src/main/java/com/ddukbbegi/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/ddukbbegi/api/store/repository/StoreRepository.java
@@ -14,7 +14,7 @@ public interface StoreRepository extends BaseRepository<Store, Long> {
     List<Store> findAllByUser_Id(Long userId);
 
     @EntityGraph(attributePaths = { "user" })
-    @Query("SELECT s FROM Store s WHERE s.name LIKE :name AND s.status = 'OPEN'")
+    @Query("SELECT s FROM Store s WHERE s.name LIKE :name")
     Page<Store> findAllOpenedStoreByName(String name, Pageable pageable);
 
     @Query("SELECT COUNT(*) < 3 FROM Store s WHERE s.user.id = :userId AND s.isPermanentlyClosed IS FALSE")

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -31,13 +31,13 @@ public class StoreService {
     @Transactional
     public StoreIdResponseDto registerStore(StoreRegisterRequestDto dto) {
 
+        User user = userRepository.findByIdOrElseThrow(1L); // TODO: user 연동
         if (!storeRepository.isStoreRegistrationAvailable(1L)) {    // TODO: user 연동
             throw new BusinessException(ResultCode.STORE_LIMIT_EXCEEDED);
         }
 
-        User user = userRepository.findByIdOrElseThrow(1L); // TODO: user 연동
-        Store entity = dto.toEntity(user);
-        Store savedStore = storeRepository.save(entity);
+        Store store = dto.toEntity(user);
+        Store savedStore = storeRepository.save(store);
 
         return StoreIdResponseDto.of(savedStore.getId());
     }

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -7,9 +7,7 @@ import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
 import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
 import com.ddukbbegi.api.store.dto.response.StoreRegisterAvailableResponseDto;
 import com.ddukbbegi.api.store.entity.Store;
-import com.ddukbbegi.api.store.enums.StoreCategory;
 import com.ddukbbegi.api.store.repository.StoreRepository;
-import com.ddukbbegi.api.store.util.TimeRangeParser;
 import com.ddukbbegi.api.user.entity.User;
 import com.ddukbbegi.api.user.repository.UserRepository;
 import com.ddukbbegi.common.component.ResultCode;
@@ -17,7 +15,6 @@ import com.ddukbbegi.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,43 +71,45 @@ public class StoreService {
 
         // TODO: 서비스 레이어에서 dto의 값을 직접 풀어서 entity로 전달하는 것은 좋지 않은 방법이다
         // 추후 MapStruct 등의 방법을 사용해 대체할 예정
+        StoreBasicInfoDto basicInfoDto = dto.getBasicInfoDto();
+
         Store store = storeRepository.findByIdOrElseThrow(storeId);
         store.updateBasicInfo(
-                dto.getName(),
-                StoreCategory.fromString(dto.getCategory()),
-                dto.getPhoneNumber(),
-                dto.getDescription()
+                basicInfoDto.getName(),
+                basicInfoDto.getCategory(),
+                basicInfoDto.getPhoneNumber(),
+                basicInfoDto.getDescription()
         );
     }
 
     @Transactional
     public void updateStoreOperationInfo(Long storeId, StoreUpdateOperationInfoRequestDto dto) {
 
-        Pair<LocalTime, LocalTime> weekdayWorkingTime = TimeRangeParser.parse(dto.getWeekdayWorkingTime());
-        Pair<LocalTime, LocalTime> weekdayBreakTime = TimeRangeParser.parse(dto.getWeekdayBreakTime());
-        Pair<LocalTime, LocalTime> weekendWorkingTime = TimeRangeParser.parse(dto.getWeekendWorkingTime());
-        Pair<LocalTime, LocalTime> weekendBreakTime = TimeRangeParser.parse(dto.getWeekendBreakTime());
+        StoreOperationInfoDto.ParsedOperationInfo parsedData = dto.getOperationInfo().toParsedData();
 
         Store store = storeRepository.findByIdOrElseThrow(storeId);
         store.updateOperationInfo(
-                weekdayWorkingTime.getFirst(),
-                weekdayWorkingTime.getSecond(),
-                weekdayBreakTime.getFirst(),
-                weekdayBreakTime.getSecond(),
-                weekendWorkingTime.getFirst(),
-                weekendWorkingTime.getSecond(),
-                weekendBreakTime.getFirst(),
-                weekendBreakTime.getSecond()
+                parsedData.getClosedDays(),
+                parsedData.getWeekdayWorkingTime().getFirst(),
+                parsedData.getWeekdayWorkingTime().getSecond(),
+                parsedData.getWeekdayBreakTime().getFirst(),
+                parsedData.getWeekdayBreakTime().getSecond(),
+                parsedData.getWeekendWorkingTime().getFirst(),
+                parsedData.getWeekendWorkingTime().getSecond(),
+                parsedData.getWeekendBreakTime().getFirst(),
+                parsedData.getWeekendBreakTime().getSecond()
         );
     }
 
     @Transactional
     public void updateStoreOrderSettings(Long storeId, StoreUpdateOrderSettingsRequestDto dto) {
 
+        StoreOrderSettingsInfo orderSettingsInfo = dto.getOrderSettingsInfo();
+
         Store store = storeRepository.findByIdOrElseThrow(storeId);
         store.updateOrderSettings(
-                dto.getMinDeliveryPrice(),
-                dto.getDeliveryTip()
+                orderSettingsInfo.getMinDeliveryPrice(),
+                orderSettingsInfo.getDeliveryTip()
         );
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -9,6 +9,21 @@ import org.springframework.stereotype.Service;
 public class StoreService {
 
     private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public StoreIdResponseDto registerStore(StoreRegisterRequestDto dto) {
+
+        if (!storeRepository.isStoreRegistrationAvailable(1L)) {    // TODO: user 연동
+            throw new BusinessException(ResultCode.STORE_LIMIT_EXCEEDED);
+        }
+
+        User user = userRepository.findByIdOrElseThrow(1L); // TODO: user 연동
+        Store entity = dto.toEntity(user);
+        Store savedStore = storeRepository.save(entity);
+
+        return StoreIdResponseDto.of(savedStore.getId());
+    }
 
     public void get() {
         storeRepository.findByIdOrElseThrow(1L);

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -1,8 +1,28 @@
 package com.ddukbbegi.api.store.service;
 
+import com.ddukbbegi.api.common.dto.PageResponseDto;
+import com.ddukbbegi.api.store.dto.request.*;
+import com.ddukbbegi.api.store.dto.response.OwnerStoreResponseDto;
+import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
+import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
+import com.ddukbbegi.api.store.dto.response.StoreRegisterAvailableResponseDto;
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreCategory;
 import com.ddukbbegi.api.store.repository.StoreRepository;
+import com.ddukbbegi.api.store.util.TimeRangeParser;
+import com.ddukbbegi.api.user.entity.User;
+import com.ddukbbegi.api.user.repository.UserRepository;
+import com.ddukbbegi.common.component.ResultCode;
+import com.ddukbbegi.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +45,84 @@ public class StoreService {
         return StoreIdResponseDto.of(savedStore.getId());
     }
 
-    public void get() {
-        storeRepository.findByIdOrElseThrow(1L);
+    @Transactional(readOnly = true)
+    public StoreRegisterAvailableResponseDto checkStoreRegistrationAvailability() {
+
+        boolean available = storeRepository.isStoreRegistrationAvailable(1L); // TODO: user 연동
+        return StoreRegisterAvailableResponseDto.of(available);
     }
 
+    @Transactional(readOnly = true)
+    public List<OwnerStoreResponseDto> getOwnerStoreList() {
+
+        List<Store> storeList = storeRepository.findAllByUser_Id(1L);   // TODO: user 연동
+        return storeList.stream()
+                .map(OwnerStoreResponseDto::fromEntity)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<StorePageItemResponseDto> getStores(String name, Pageable pageable) {
+
+        Page<StorePageItemResponseDto> result = storeRepository.findAllOpenedStoreByName("%" + name + "%", pageable)
+                .map(StorePageItemResponseDto::fromEntity);
+        return PageResponseDto.toDto(result);
+    }
+
+    @Transactional
+    public void updateStoreBasicInfo(Long storeId, StoreUpdateBasicInfoRequestDto dto) {
+
+        // TODO: 서비스 레이어에서 dto의 값을 직접 풀어서 entity로 전달하는 것은 좋지 않은 방법이다
+        // 추후 MapStruct 등의 방법을 사용해 대체할 예정
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        store.updateBasicInfo(
+                dto.getName(),
+                StoreCategory.fromString(dto.getCategory()),
+                dto.getPhoneNumber(),
+                dto.getDescription()
+        );
+    }
+
+    @Transactional
+    public void updateStoreOperationInfo(Long storeId, StoreUpdateOperationInfoRequestDto dto) {
+
+        Pair<LocalTime, LocalTime> weekdayWorkingTime = TimeRangeParser.parse(dto.getWeekdayWorkingTime());
+        Pair<LocalTime, LocalTime> weekdayBreakTime = TimeRangeParser.parse(dto.getWeekdayBreakTime());
+        Pair<LocalTime, LocalTime> weekendWorkingTime = TimeRangeParser.parse(dto.getWeekendWorkingTime());
+        Pair<LocalTime, LocalTime> weekendBreakTime = TimeRangeParser.parse(dto.getWeekendBreakTime());
+
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        store.updateOperationInfo(
+                weekdayWorkingTime.getFirst(),
+                weekdayWorkingTime.getSecond(),
+                weekdayBreakTime.getFirst(),
+                weekdayBreakTime.getSecond(),
+                weekendWorkingTime.getFirst(),
+                weekendWorkingTime.getSecond(),
+                weekendBreakTime.getFirst(),
+                weekendBreakTime.getSecond()
+        );
+    }
+
+    @Transactional
+    public void updateStoreOrderSettings(Long storeId, StoreUpdateOrderSettingsRequestDto dto) {
+
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        store.updateOrderSettings(
+                dto.getMinDeliveryPrice(),
+                dto.getDeliveryTip()
+        );
+    }
+
+    public void updateTemporarilyClosed(Long storeId, StoreUpdateStatusRequest dto) {
+
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        store.updateTemporarilyClosed(dto.isStatus());
+    }
+
+    public void updatePermanentlyClosed(Long storeId, StoreUpdateStatusRequest dto) {
+
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        store.updatePermanentlyClosed(dto.isStatus());
+    }
 }

--- a/src/main/java/com/ddukbbegi/api/store/util/TimeRangeParser.java
+++ b/src/main/java/com/ddukbbegi/api/store/util/TimeRangeParser.java
@@ -1,0 +1,24 @@
+package com.ddukbbegi.api.store.util;
+
+import com.ddukbbegi.common.component.ResultCode;
+import com.ddukbbegi.common.exception.BusinessException;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalTime;
+
+public class TimeRangeParser {
+
+    public static Pair<LocalTime, LocalTime> parse(String range) {
+
+        if (range == null || !range.matches("^\\d{2}:\\d{2}-\\d{2}:\\d{2}$")) {
+            throw new BusinessException(ResultCode.VALID_FAIL, "올바르지 않은 시간 범위 형식입니다.");
+        }
+
+        String[] parts = range.split("-");
+        LocalTime start = LocalTime.parse(parts[0]);
+        LocalTime end = LocalTime.parse(parts[1]);
+
+        return Pair.of(start, end);
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/common/component/ResultCode.java
+++ b/src/main/java/com/ddukbbegi/common/component/ResultCode.java
@@ -26,11 +26,8 @@ public enum ResultCode {
 
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "알 수 없는 오류"),
 
-    /* 주문 도메인 */
-    CONTAIN_DIFFERENT_STORE_MENU(HttpStatus.BAD_REQUEST,"E201","서로 다른 가게의 메뉴가 포함되어 있습니다."),
-    STORE_NOT_WORKING(HttpStatus.BAD_REQUEST,"E202" ,"가게 운영중이 아닙니다." ),
-    MENU_IS_DELETED(HttpStatus.BAD_REQUEST, "E203", "삭제된 메뉴가 포함되어 있습니다."),
-    UNDER_MIN_DELIVERY_PRICE(HttpStatus.BAD_REQUEST, "E204", "최소 주문 금액이 충족되지 않았습니다." );
+    /* 가게 */
+    STORE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "E301", "가게 등록 가능 개수를 초과했습니다. 최대 3개까지만 등록할 수 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ddukbbegi/common/component/ResultCode.java
+++ b/src/main/java/com/ddukbbegi/common/component/ResultCode.java
@@ -26,8 +26,14 @@ public enum ResultCode {
 
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "알 수 없는 오류"),
 
-    /* 가게 */
-    STORE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "E301", "가게 등록 가능 개수를 초과했습니다. 최대 3개까지만 등록할 수 있습니다.");
+    /* 가게 도메인 */
+    STORE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "E301", "가게 등록 가능 개수를 초과했습니다. 최대 3개까지만 등록할 수 있습니다."),
+
+    /* 주문 도메인 */
+    CONTAIN_DIFFERENT_STORE_MENU(HttpStatus.BAD_REQUEST,"E201","서로 다른 가게의 메뉴가 포함되어 있습니다."),
+    STORE_NOT_WORKING(HttpStatus.BAD_REQUEST,"E202" ,"가게 운영중이 아닙니다." ),
+    MENU_IS_DELETED(HttpStatus.BAD_REQUEST, "E203", "삭제된 메뉴가 포함되어 있습니다."),
+    UNDER_MIN_DELIVERY_PRICE(HttpStatus.BAD_REQUEST, "E204", "최소 주문 금액이 충족되지 않았습니다." );
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 🔎 작업 내용

- 가게 관련 CRUD 구현
  - 가게 등록, 등록 가능 여부 및 가게 목록 조회, 가게 정보 업데이트 등
- 가게 entity 수정

## 요청 데이터 예시
- 가게 등록
```json
{
  "basicInfoDto": {
    "name": "맛있는김밥",
    "category": "한식",
    "phoneNumber": "010-1234-5678",
    "description": "신선한 재료로 매일 준비합니다."
  },
  "operationInfo": {
    "closedDays": "SUN,MON",
    "weekdayWorkingTime": "09:00-18:00",
    "weekdayBreakTime": "14:00-15:00",
    "weekendWorkingTime": "10:00-17:00",
    "weekendBreakTime": "13:00-14:00"
  },
  "orderSettingsInfo": {
    "minDeliveryPrice": 12000,
    "deliveryTip": 2000
  }
}
```
- 가게 운영정보 수정
```json
{
  "operationInfo": {
    "closedDays": "TUE,MON",
    "weekdayWorkingTime": "09:00-18:00",
    "weekdayBreakTime": "14:00-15:00",
    "weekendWorkingTime": "10:00-18:00",
    "weekendBreakTime": "13:00-14:00"
  }
}
```

  <br/>

## ➕ 트러블 슈팅

- 가게의 영업 상태인 `status` 칼럼 값을 DB에서 가지고 있는게 맞나 고민함
  - 영업 시간, 휴게 시간, 사장이 지정한 임시 휴업 상태 등 다양한 요소를 고려해 계산해야 하기 때문
  - 이를 DB에 주기적으로 갱신하는 것은 비효율적이라고 판단함
  => `status` 칼럼 삭제 + DTO에서 반환 시 계산하기로 함
- DTO 중복 문제 발생
  - 가게 등록과 수정 시 사용하는 필드와 validation이 반복해서 사용됨
  - 시간 데이터를 파싱하는 로직 또한 마찬가지
  - 공통된 부분을 분리함

  <br/>

## 🔧 해결해야할 문제

- 유저 연동 필요
- 아직 가게 상세 조회 등은 구현되어 있지 않음
  - 비즈니스 로직에서 구현할 예정
- 가게 목록을 Page로 조회했을 때 이 status가 OPEN인 가게들을 우선적으로 보여줘야 함
  - 그러나 status 정보는 DB에서 가지고 있지 않음 -> 튜터님께 여쭤봐야 함
- service -> repository 에서 dto 값을 하나하나 풀어서 전달해주고 있음
  -  서비스 로직이 dto에 의존하게 되므로 좋지 않은 방식
  - MapStruct 같은 기술 고려 중

## Ref
- #22 
- #26 

This closes #25 