### PR TITLE
[Refactor] #55 :  JWT 기반 인증을 위한 CustomUserDetails 경량화

### DIFF
--- a/src/main/java/com/ddukbbegi/common/auth/CustomUserDetails.java
+++ b/src/main/java/com/ddukbbegi/common/auth/CustomUserDetails.java
@@ -28,7 +28,7 @@ public class CustomUserDetails implements UserDetails {
         return String.valueOf(userId);  // 이메일 (아이디)
     }
 
-    // JWT 인증 방식에서는 Password 불필요
+    // JWT 인증 방식에서는 Password 불필요하여 해당 부분 공백으로 반환
     @Override
     public String getPassword() {
         return " ";

--- a/src/main/java/com/ddukbbegi/common/auth/CustomUserDetails.java
+++ b/src/main/java/com/ddukbbegi/common/auth/CustomUserDetails.java
@@ -11,16 +11,10 @@ import java.util.Collection;
 @Getter
 public class CustomUserDetails implements UserDetails {
     private Long userId;
-    private String email;
-    private String password;
-    private UserRole userRole;
     private Collection<? extends GrantedAuthority> authorities;
 
-    public CustomUserDetails(Long userId, String email, String password, UserRole userRole, Collection<? extends GrantedAuthority> authorities) {
+    public CustomUserDetails(Long userId, Collection<? extends GrantedAuthority> authorities) {
         this.userId = userId;
-        this.email = email;
-        this.password = password;
-        this.userRole = userRole;
         this.authorities = authorities;
     }
 
@@ -28,18 +22,16 @@ public class CustomUserDetails implements UserDetails {
         return userId;
     }
 
-    public UserRole getUserRole() {
-        return userRole;
-    }
-
+    // Username 대신 userId 로 설정
     @Override
     public String getUsername() {
-        return email;  // 이메일 (아이디)
+        return String.valueOf(userId);  // 이메일 (아이디)
     }
 
+    // JWT 인증 방식에서는 Password 불필요
     @Override
     public String getPassword() {
-        return password;
+        return " ";
     }
 
     @Override

--- a/src/main/java/com/ddukbbegi/common/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/ddukbbegi/common/auth/CustomUserDetailsService.java
@@ -22,18 +22,15 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        // 데이터베이스에서 이메일로 사용자 조회
-        User userEntity = userRepository.findByEmail(username)
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        // 데이터베이스에서 userId로 사용자 조회
+        User userEntity = userRepository.findById(Long.valueOf(userId))
                 .orElseThrow(() ->
                         new BusinessException(ResultCode.NOT_FOUND));
 
         // 사용자 정보를 CustomUserDetails 객체로 반환
         return new CustomUserDetails(
                 userEntity.getId(),  // userId
-                userEntity.getEmail(),  // 이메일
-                userEntity.getPassword(), // 비밀번호
-                userEntity.getUserRole(), // userRole
                 getAuthorities(userEntity) // 권한 설정
         );
     }


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: [태그] #이슈번호 : 간단한 설명
  예시: [Feat] #12 : 로그인 API 연동
-->


## 🔎 작업 내용

- 1. CustomerUserDetails 경량화
- 2. email 로 되어 있던 로직을 UserID 로직으로 변경

  <br/>

## ➕ 트러블 슈팅

1. 구현하면서 마주한 문제
- null 값이 뜨는 경우 발생.
![image](https://github.com/user-attachments/assets/84c3c50d-c48d-4f19-afc1-278353cf76e7)
2. 원인 분석
- 알고보니 로직 내부에서 findByEmail  를 UserId 로 찾고 있었음.
3. 해결
- 해당 부분을 findById 로 수정 후 정상 작동

  <br/>

## 🔧 해결해야할 문제

- 현재 상태에서는 구현이나 동작에는 문제가 없으나 유의 사항.
- 1. UserDetails 인터페이스는 `getPassword()` 메서드를 **필수로 구현**해야 하기 때문에, 기본적으로 `password` 를 요구
- 2. 실제 어딘가에서 `getPassword()` 호출했는데 `null`이면 `NPE` 발생할 수 있음 => 그리하여 현재는 해당 값을 **빈 문자열** 로 뒀음. 
- 3. "빈 문자열"도 실제 문자열로 인식됨 => 어떤 라이브러리나 기능에서는 ""을 **"입력된 값"**으로 인식할 수 있어서, 의도하지 않은 결과를 낼 수도 있음.

결론 " UserDetails  객체에서 비밀번호를 안 가져다 쓰면, 문제가 안 생긴다. "

  <br/>
  
  ## 참고
** " 수정했어도 이전 `@AuthenticationPrincipal` 그대로 쓰시면 됩니다.
1. Controller 에서 파라미터로 `@AuthenticationPrincipal CustomUserDetails userDetails` 주시고,
2. `Long userId = userDetails.getUserId()` 이렇게 쓰시면 됩니다. "**
아래는 예시 사진입니다 !
![image](https://github.com/user-attachments/assets/629480b9-e5af-43dc-830b-f093228e874e)
<br/>

- #53 
- #38
<br/>
