### PR TITLE
[Feat] #47 :  주문 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ddukbbegi/api/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/auth/dto/request/LoginRequestDto.java
@@ -1,11 +1,6 @@
 package com.ddukbbegi.api.auth.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class LoginRequestDto {
-    private final String email;
-    private final String password;
+
+public record LoginRequestDto(String email, String password) {
 }

--- a/src/main/java/com/ddukbbegi/api/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/auth/dto/request/SignupRequestDto.java
@@ -4,33 +4,16 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class SignupRequestDto {
 
-    @NotBlank(message = "이메일은 필수 입력값입니다.")
-    @Email(message = "유효한 이메일 주소를 입력하세요.")
-    @Size(max = 50)
-    private final String email;
+public record SignupRequestDto(
+        @NotBlank(message = "이메일은 필수 입력값입니다.") @Email(message = "유효한 이메일 주소를 입력하세요.") @Size(max = 50) String email,
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.") @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다."
+        ) String password,
+        @NotBlank(message = "이름은 필수 입력값입니다.") @Size(max = 10, message = "이름은 10자 이내로 입력해주세요.") String name,
+        @NotBlank(message = "전화번호는 필수 입력값입니다.") @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.") String phone,
+        @NotBlank(message = "권한은 필수값 입니다.") String role) {
 
-    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
-            message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다."
-    )
-    private final String password;
-
-    @NotBlank(message = "이름은 필수 입력값입니다.")
-    @Size(max = 10, message = "이름은 10자 이내로 입력해주세요.")
-    private final String name;
-
-    @NotBlank(message = "전화번호는 필수 입력값입니다.")
-    @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
-    private final String phone;
-
-    @NotBlank(message = "권한은 필수값 입니다.")
-    private final String role;
 }

--- a/src/main/java/com/ddukbbegi/api/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/ddukbbegi/api/auth/service/AuthServiceImpl.java
@@ -2,7 +2,6 @@ package com.ddukbbegi.api.auth.service;
 
 import com.ddukbbegi.api.auth.dto.request.LoginRequestDto;
 import com.ddukbbegi.api.auth.dto.request.SignupRequestDto;
-import com.ddukbbegi.api.auth.dto.request.UpdatePasswordRequestDto;
 import com.ddukbbegi.api.auth.dto.response.LoginResponseDto;
 import com.ddukbbegi.api.auth.dto.response.SignupResponseDto;
 import com.ddukbbegi.api.auth.entity.Auth;
@@ -33,19 +32,19 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public SignupResponseDto signup(SignupRequestDto signUpRequestDto) {
 
-        if (userRepository.existsByEmail(signUpRequestDto.getEmail())) {
+        if (userRepository.existsByEmail(signUpRequestDto.email())) {
             throw new BusinessException(VALID_FAIL, "이미 존재하는 Email 입니다.");
         }
 
-        String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
+        String encodedPassword = passwordEncoder.encode(signUpRequestDto.password());
 
-        UserRole userRole = UserRole.of(signUpRequestDto.getRole());
+        UserRole userRole = UserRole.of(signUpRequestDto.role());
 
         User user = User.of(
-                signUpRequestDto.getEmail(),
+                signUpRequestDto.email(),
                 encodedPassword,
-                signUpRequestDto.getName(),
-                signUpRequestDto.getPhone(),
+                signUpRequestDto.name(),
+                signUpRequestDto.phone(),
                 userRole);
 
         userRepository.save(user);
@@ -57,13 +56,13 @@ public class AuthServiceImpl implements AuthService {
     public LoginResponseDto login(LoginRequestDto requestDto) {
 
         // 1. User Email 일치 여부 확인
-        User findUser = userRepository.findByEmail(requestDto.getEmail())
+        User findUser = userRepository.findByEmail(requestDto.email())
                 .orElseThrow(() ->
-                        new BusinessException(ResultCode.NOT_FOUND, "해당 Entity를 찾을 수 없습니다. email = " + requestDto.getEmail())
+                        new BusinessException(ResultCode.NOT_FOUND, "해당 Entity를 찾을 수 없습니다. email = " + requestDto.email())
                 );
 
         // 2. Pwd 일치 여부
-        if (!passwordEncoder.matches(requestDto.getPassword(), findUser.getPassword())) {
+        if (!passwordEncoder.matches(requestDto.password(), findUser.getPassword())) {
             throw new BusinessException(LOGIN_FAILED);
         }
 

--- a/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.menu.entity.Menu;
 
-import java.util.List;
-
 public interface MenuRepository extends BaseRepository<Menu, Long> {
 	@Query("SELECT m FROM Menu m WHERE m.id = :id AND m.storeId = :storeId AND m.isDeleted = false")
 	Menu findMenuByIdAndStoreIdAndIsDeletedFalse(long storeId, long id);

--- a/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
+++ b/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
@@ -1,10 +1,14 @@
 package com.ddukbbegi.api.order.controller;
 
+import com.ddukbbegi.api.common.dto.PageResponseDto;
 import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
+import com.ddukbbegi.api.order.dto.response.OrderHistoryOwnerResponseDto;
+import com.ddukbbegi.api.order.dto.response.OrderHistoryUserResponseDto;
 import com.ddukbbegi.api.order.service.OrderService;
 import com.ddukbbegi.common.component.BaseResponse;
 import com.ddukbbegi.common.component.ResultCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,5 +23,18 @@ public class OrderController {
         return BaseResponse.success(orderService.createOrder(request, 1L), ResultCode.OK);
     }
 
+    @GetMapping("/orders")
+    public BaseResponse<PageResponseDto<OrderHistoryUserResponseDto>> getMyOrders(Pageable pageable) {
+        long userId = 1L;
+        PageResponseDto<OrderHistoryUserResponseDto> result = orderService.getOrdersForUser(userId, pageable);
+        return BaseResponse.success(result, ResultCode.OK);
+    }
+
+    @GetMapping("/owner/store/{storeId}/orders")
+    public BaseResponse<PageResponseDto<OrderHistoryOwnerResponseDto>> getOrdersForOwner(@PathVariable long storeId, Pageable pageable) {
+        long userId = 2L;
+        PageResponseDto<OrderHistoryOwnerResponseDto> result = orderService.getOrdersForOwner(userId, pageable);
+        return BaseResponse.success(result, ResultCode.OK);
+    }
 
 }

--- a/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
+++ b/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
@@ -5,10 +5,12 @@ import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
 import com.ddukbbegi.api.order.dto.response.OrderHistoryOwnerResponseDto;
 import com.ddukbbegi.api.order.dto.response.OrderHistoryUserResponseDto;
 import com.ddukbbegi.api.order.service.OrderService;
+import com.ddukbbegi.common.auth.CustomUserDetails;
 import com.ddukbbegi.common.component.BaseResponse;
 import com.ddukbbegi.common.component.ResultCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,21 +21,19 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping("/orders")
-    public BaseResponse<Long> createOrder(@Validated @RequestBody OrderCreateRequestDto request) {
-        return BaseResponse.success(orderService.createOrder(request, 1L), ResultCode.OK);
+    public BaseResponse<Long> createOrder(@AuthenticationPrincipal CustomUserDetails userDetails, @Validated @RequestBody OrderCreateRequestDto request) {
+        return BaseResponse.success(orderService.createOrder(request, userDetails.getUserId()), ResultCode.OK);
     }
 
     @GetMapping("/orders")
-    public BaseResponse<PageResponseDto<OrderHistoryUserResponseDto>> getMyOrders(Pageable pageable) {
-        long userId = 1L;
-        PageResponseDto<OrderHistoryUserResponseDto> result = orderService.getOrdersForUser(userId, pageable);
+    public BaseResponse<PageResponseDto<OrderHistoryUserResponseDto>> getOrdersForUser(@AuthenticationPrincipal CustomUserDetails userDetails, Pageable pageable) {
+        PageResponseDto<OrderHistoryUserResponseDto> result = orderService.getOrdersForUser(userDetails.getUserId(), pageable);
         return BaseResponse.success(result, ResultCode.OK);
     }
 
     @GetMapping("/owner/store/{storeId}/orders")
     public BaseResponse<PageResponseDto<OrderHistoryOwnerResponseDto>> getOrdersForOwner(@PathVariable long storeId, Pageable pageable) {
-        long userId = 2L;
-        PageResponseDto<OrderHistoryOwnerResponseDto> result = orderService.getOrdersForOwner(userId, pageable);
+        PageResponseDto<OrderHistoryOwnerResponseDto> result = orderService.getOrdersForOwner(storeId, pageable);
         return BaseResponse.success(result, ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
+++ b/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
@@ -21,18 +21,20 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping("/orders")
-    public BaseResponse<Long> createOrder(@AuthenticationPrincipal CustomUserDetails userDetails, @Validated @RequestBody OrderCreateRequestDto request) {
+    public BaseResponse<Long> createOrder(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                          @Validated @RequestBody OrderCreateRequestDto request) {
         return BaseResponse.success(orderService.createOrder(request, userDetails.getUserId()), ResultCode.OK);
     }
 
     @GetMapping("/orders")
-    public BaseResponse<PageResponseDto<OrderHistoryUserResponseDto>> getOrdersForUser(@AuthenticationPrincipal CustomUserDetails userDetails, Pageable pageable) {
-        PageResponseDto<OrderHistoryUserResponseDto> result = orderService.getOrdersForUser(userDetails.getUserId(), pageable);
+    public BaseResponse<PageResponseDto<OrderHistoryUserResponseDto>> getOrdersForUser(//@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                       Pageable pageable) {
+        PageResponseDto<OrderHistoryUserResponseDto> result = orderService.getOrdersForUser(1L, pageable);
         return BaseResponse.success(result, ResultCode.OK);
     }
 
-    @GetMapping("/owner/store/{storeId}/orders")
-    public BaseResponse<PageResponseDto<OrderHistoryOwnerResponseDto>> getOrdersForOwner(@PathVariable long storeId, Pageable pageable) {
+    @GetMapping("/owner/stores/{storeId}/orders")
+    public BaseResponse<PageResponseDto<OrderHistoryOwnerResponseDto>> getOrdersForOwner(@PathVariable("storeId") long storeId, Pageable pageable) {
         PageResponseDto<OrderHistoryOwnerResponseDto> result = orderService.getOrdersForOwner(storeId, pageable);
         return BaseResponse.success(result, ResultCode.OK);
     }

--- a/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
+++ b/src/main/java/com/ddukbbegi/api/order/controller/OrderController.java
@@ -9,13 +9,15 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/orders")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class OrderController {
     private final OrderService orderService;
 
-    @PostMapping
+    @PostMapping("/orders")
     public BaseResponse<Long> createOrder(@Validated @RequestBody OrderCreateRequestDto request) {
         return BaseResponse.success(orderService.createOrder(request, 1L), ResultCode.OK);
     }
+
+
 }

--- a/src/main/java/com/ddukbbegi/api/order/dto/response/OrderHistoryOwnerResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/order/dto/response/OrderHistoryOwnerResponseDto.java
@@ -1,0 +1,35 @@
+package com.ddukbbegi.api.order.dto.response;
+
+import com.ddukbbegi.api.order.entity.Order;
+import com.ddukbbegi.api.order.entity.OrderMenu;
+
+import java.util.List;
+
+public record OrderHistoryOwnerResponseDto(
+        Long orderId,
+        List<MenuItem> orderItems,
+        String status,
+        String userPhoneNumber
+) {
+    public static OrderHistoryOwnerResponseDto from(Order order, List<OrderMenu> orderMenus) {
+        return new OrderHistoryOwnerResponseDto(
+                order.getId(),
+                orderMenus.stream()
+                        .map(MenuItem::from)
+                        .toList(),
+                order.getOrderStatus().name(),
+                order.getUser().getPhone()
+        );
+    }
+
+    public record MenuItem(Long menuId, String menuName, int count) {
+        public static MenuItem from(OrderMenu om) {
+            return new MenuItem(
+                    om.getMenu().getId(),
+                    om.getMenu().getName(),
+                    om.getCount()
+            );
+        }
+    }
+}
+

--- a/src/main/java/com/ddukbbegi/api/order/dto/response/OrderHistoryUserResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/order/dto/response/OrderHistoryUserResponseDto.java
@@ -1,0 +1,34 @@
+package com.ddukbbegi.api.order.dto.response;
+
+import com.ddukbbegi.api.order.entity.Order;
+import com.ddukbbegi.api.order.entity.OrderMenu;
+
+import java.util.List;
+
+public record OrderHistoryUserResponseDto(
+        Long orderId,
+        List<MenuItem> orderMenus,
+        String status,
+        String storeName,
+        boolean isReviewed
+) {
+    public static OrderHistoryUserResponseDto from(Order order, List<OrderMenu> orderMenus, boolean isReviewed) {
+        return new OrderHistoryUserResponseDto(
+                order.getId(),
+                orderMenus.stream().map(MenuItem::from).toList(),
+                order.getOrderStatus().name(),
+                order.getStore().getName(),
+                isReviewed
+        );
+    }
+
+    public record MenuItem(Long menuId, String menuName, int count) {
+        public static MenuItem from(OrderMenu orderMenu) {
+            return new MenuItem(
+                    orderMenu.getMenu().getId(),
+                    orderMenu.getMenu().getName(),
+                    orderMenu.getCount()
+            );
+        }
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/order/entity/OrderMenu.java
+++ b/src/main/java/com/ddukbbegi/api/order/entity/OrderMenu.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders_menus")
 public class OrderMenu extends BaseUserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderMenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderMenuRepository.java
@@ -3,5 +3,8 @@ package com.ddukbbegi.api.order.repository;
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.order.entity.OrderMenu;
 
+import java.util.List;
+
 public interface OrderMenuRepository extends BaseRepository<OrderMenu, Long> {
+    List<OrderMenu> findByOrderIdInWithMenu(List<Long> orderIds);
 }

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderMenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderMenuRepository.java
@@ -2,9 +2,12 @@ package com.ddukbbegi.api.order.repository;
 
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.order.entity.OrderMenu;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrderMenuRepository extends BaseRepository<OrderMenu, Long> {
-    List<OrderMenu> findByOrderIdInWithMenu(List<Long> orderIds);
+    @Query("SELECT om FROM OrderMenu om JOIN FETCH om.menu WHERE om.order.id IN :orderIds")
+    List<OrderMenu> findByOrderIdInWithMenu(@Param("orderIds") List<Long> orderIds);
 }

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -8,7 +8,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends BaseRepository<Order, Long> {
-    Page<Order> findAllByUserId(long userId, Pageable pageable);
+    @Query(value = """
+    SELECT o FROM Order o
+    JOIN FETCH o.store
+    WHERE o.user.id = :userId
+    """,
+            countQuery = """
+    SELECT COUNT(o) FROM Order o
+    WHERE o.user.id = :userId
+    """)
+    Page<Order> findAllByUserId(@Param(value = "userId") long userId, Pageable pageable);
 
     @Query(
             value = "SELECT o FROM Order o JOIN FETCH o.user WHERE o.store.id = :storeId",

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -5,6 +5,7 @@ import com.ddukbbegi.api.order.entity.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends BaseRepository<Order, Long> {
     Page<Order> findAllByUserId(long userId, Pageable pageable);
@@ -13,5 +14,5 @@ public interface OrderRepository extends BaseRepository<Order, Long> {
             value = "SELECT o FROM Order o JOIN FETCH o.user WHERE o.store.id = :storeId",
             countQuery = "SELECT count(o) FROM Order o WHERE o.store.id = :storeId"
     )
-    Page<Order> findAllByStoreId(long storeId, Pageable pageable);
+    Page<Order> findAllByStoreId(@Param(value = "storeId") long storeId, Pageable pageable);
 }

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -2,6 +2,16 @@ package com.ddukbbegi.api.order.repository;
 
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.order.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OrderRepository extends BaseRepository<Order, Long> {
+    Page<Order> findAllByUserId(long userId, Pageable pageable);
+
+    @Query(
+            value = "SELECT o FROM Order o JOIN FETCH o.user WHERE o.store.id = :storeId",
+            countQuery = "SELECT count(o) FROM Order o WHERE o.store.id = :storeId"
+    )
+    Page<Order> findAllByStoreId(long storeId, Pageable pageable);
 }

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -148,19 +148,21 @@ public class OrderService {
                 OrderHistoryUserResponseDto.from(
                         order,
                         orderMenuMap.getOrDefault(order.getId(), List.of()),
-                        isReviewed(orderIds, order)
+                        false
+                        //todo: Review에 Order 참조되면 주석 해제
+                        //isReviewed(orderIds, order)
                 )
         );
 
         return PageResponseDto.toDto(result);
     }
 
-    private boolean isReviewed(List<Long> orderIds, Order order) {
-        List<Long> reviewedOrderIds = reviewRepository.findReviewedOrderIds(orderIds);
-        Set<Long> reviewedOrderIdSet = new HashSet<>(reviewedOrderIds);
-
-        return reviewedOrderIdSet.contains(order.getId());
-    }
+//    private boolean isReviewed(List<Long> orderIds, Order order) {
+//        List<Long> reviewedOrderIds = reviewRepository.findReviewedOrderIds(orderIds);
+//        Set<Long> reviewedOrderIdSet = new HashSet<>(reviewedOrderIds);
+//
+//        return reviewedOrderIdSet.contains(order.getId());
+//    }
 
     @Transactional(readOnly = true)
     public PageResponseDto<OrderHistoryOwnerResponseDto> getOrdersForOwner(long storeId, Pageable pageable) {

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -1,12 +1,16 @@
 package com.ddukbbegi.api.order.service;
 
+import com.ddukbbegi.api.common.dto.PageResponseDto;
 import com.ddukbbegi.api.menu.entity.Menu;
 import com.ddukbbegi.api.menu.repository.MenuRepository;
 import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
+import com.ddukbbegi.api.order.dto.response.OrderHistoryOwnerResponseDto;
+import com.ddukbbegi.api.order.dto.response.OrderHistoryUserResponseDto;
 import com.ddukbbegi.api.order.entity.Order;
 import com.ddukbbegi.api.order.entity.OrderMenu;
 import com.ddukbbegi.api.order.repository.OrderMenuRepository;
 import com.ddukbbegi.api.order.repository.OrderRepository;
+import com.ddukbbegi.api.review.repository.ReviewRepository;
 import com.ddukbbegi.api.store.entity.Store;
 import com.ddukbbegi.api.store.repository.StoreRepository;
 import com.ddukbbegi.api.user.entity.User;
@@ -14,12 +18,18 @@ import com.ddukbbegi.api.user.repository.UserRepository;
 import com.ddukbbegi.common.component.ResultCode;
 import com.ddukbbegi.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +40,7 @@ public class OrderService {
     private final MenuRepository menuRepository;
     private final StoreRepository storeRepository;
     private final OrderMenuRepository orderMenuRepository;
+    private final ReviewRepository reviewRepository;
 
     private final Clock clock;
 
@@ -120,5 +131,55 @@ public class OrderService {
         if (!allSameStore) {
             throw new BusinessException(ResultCode.CONTAIN_DIFFERENT_STORE_MENU);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<OrderHistoryUserResponseDto> getOrdersForUser(long userId, Pageable pageable) {
+        Page<Order> orders = orderRepository.findAllByUserId(userId, pageable);
+        List<Long> orderIds = orders.getContent().stream()
+                .map(Order::getId)
+                .toList();
+
+        List<OrderMenu> orderMenus = orderMenuRepository.findByOrderIdInWithMenu(orderIds);
+        Map<Long, List<OrderMenu>> orderMenuMap = orderMenus.stream()
+                .collect(Collectors.groupingBy(om -> om.getOrder().getId()));
+
+        Page<OrderHistoryUserResponseDto> result = orders.map(order ->
+                OrderHistoryUserResponseDto.from(
+                        order,
+                        orderMenuMap.getOrDefault(order.getId(), List.of()),
+                        isReviewed(orderIds, order)
+                )
+        );
+
+        return PageResponseDto.toDto(result);
+    }
+
+    private boolean isReviewed(List<Long> orderIds, Order order) {
+        List<Long> reviewedOrderIds = reviewRepository.findReviewedOrderIds(orderIds);
+        Set<Long> reviewedOrderIdSet = new HashSet<>(reviewedOrderIds);
+
+        return reviewedOrderIdSet.contains(order.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<OrderHistoryOwnerResponseDto> getOrdersForOwner(long storeId, Pageable pageable) {
+        Page<Order> orders = orderRepository.findAllByStoreId(storeId, pageable);
+        List<Long> orderIds = orders.getContent().stream()
+                .map(Order::getId)
+                .toList();
+
+        List<OrderMenu> orderMenus = orderMenuRepository.findByOrderIdInWithMenu(orderIds);
+        Map<Long, List<OrderMenu>> orderMenuMap = orderMenus.stream()
+                .collect(Collectors.groupingBy(om -> om.getOrder().getId()));
+
+        Page<OrderHistoryOwnerResponseDto> result = orders.map(order ->
+                OrderHistoryOwnerResponseDto.from(
+                        order,
+                        orderMenuMap.getOrDefault(order.getId(), List.of())
+                )
+        );
+
+        return PageResponseDto.toDto(result);
     }
 }

--- a/src/main/java/com/ddukbbegi/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ddukbbegi/api/review/repository/ReviewRepository.java
@@ -19,6 +19,7 @@ public interface ReviewRepository extends BaseRepository<Review, Long> {
     @Query("select r from Review r join fetch r.user where r.id = :reviewId")
     Optional<Review> findByIdWithUser(@Param("reviewId") Long reviewId);
 
-    @Query("SELECT r.order.id FROM Review r WHERE r.order.id IN :orderIds")
-    List<Long> findReviewedOrderIds(@Param("orderIds") List<Long> orderIds);
+    // todo: 리뷰 엔티티에 주문 참조되면 주석 해제
+//    @Query("SELECT r.order.id FROM Review r WHERE r.order.id IN :orderIds")
+//    List<Long> findReviewedOrderIds(@Param("orderIds") List<Long> orderIds);
 }

--- a/src/main/java/com/ddukbbegi/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ddukbbegi/api/review/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReviewRepository extends BaseRepository<Review, Long> {
@@ -17,4 +18,7 @@ public interface ReviewRepository extends BaseRepository<Review, Long> {
 
     @Query("select r from Review r join fetch r.user where r.id = :reviewId")
     Optional<Review> findByIdWithUser(@Param("reviewId") Long reviewId);
+
+    @Query("SELECT r.order.id FROM Review r WHERE r.order.id IN :orderIds")
+    List<Long> findReviewedOrderIds(@Param("orderIds") List<Long> orderIds);
 }

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
@@ -6,6 +6,7 @@ import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
 import com.ddukbbegi.api.order.entity.Order;
 import com.ddukbbegi.api.order.repository.OrderMenuRepository;
 import com.ddukbbegi.api.order.repository.OrderRepository;
+import com.ddukbbegi.api.review.repository.ReviewRepository;
 import com.ddukbbegi.api.store.entity.Store;
 import com.ddukbbegi.api.store.repository.StoreRepository;
 import com.ddukbbegi.api.user.entity.User;
@@ -48,6 +49,9 @@ class OrderServiceTest {
     @Mock
     private OrderMenuRepository orderMenuRepository;
 
+    @Mock
+    private ReviewRepository reviewRepository;
+
     private User user;
 
     private OrderService orderService;
@@ -58,7 +62,7 @@ class OrderServiceTest {
                 LocalDateTime.of(2024, 1, 1, 10, 0).toInstant(ZoneOffset.UTC),
                 ZoneId.systemDefault()
         );
-        orderService = new OrderService(orderRepository, userRepository, menuRepository, storeRepository, orderMenuRepository,fixedClock);
+        orderService = new OrderService(orderRepository, userRepository, menuRepository, storeRepository, orderMenuRepository,reviewRepository,fixedClock);
 
         user = User.of("test@email.com", "pw", "홍길동", "010-1234-5678", UserRole.USER);
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: [태그] #이슈번호 : 간단한 설명
  예시: [Feat] #12 : 로그인 API 연동
-->


## 🔎 작업 내용

- 주문 목록 조회 (일반 유저)
- ```json  {
  "data": {
    "data": [
      {
        "orderId": 1,
        "orderMenus": [
          {
            "menuId": 1,
            "menuName": "불고기 버거",
            "count": 1
          },
          {
            "menuId": 2,
            "menuName": "치즈 감자튀김",
            "count": 2
          }
        ],
        "status": "WAITING",
        "storeName": "김밥천국 강남점",
        "isReviewed": false
      }
    ],
    "totalElements": 5,
    "page": 1,
    "size": 20,
    "totalPages": 1
  },
  "result": {
    "status": 200,
    "code": "A001",
    "message": "요청 처리 성공",
    "timestamp": "2025-04-25T00:50:02"
  }
}
````

- 주문 목록 조회 (사장님)
- 
```json 
{
    "data": {
        "data": [
            {
                "orderId": 1,
                "orderItems": [
                    {
                        "menuId": 1,
                        "menuName": "불고기 버거",
                        "count": 1
                    },
                    {
                        "menuId": 2,
                        "menuName": "치즈 감자튀김",
                        "count": 2
                    }
                ],
                "status": "WAITING",
                "userPhoneNumber": "01000000000"
            },
           ...
        ],
        "totalElements": 8,
        "page": 1,
        "size": 20,
        "totalPages": 1
    },
    "result": {
        "status": 200,
        "code": "A001",
        "message": "요청 처리 성공",
        "timestamp": "2025-04-25T00:57:05"
    }
}
````

## ➕ 트러블 슈팅

- 구현하면서 마주한 문제
최대한 단방향 연관관계를 사용하고 싶어서, OrderMenus 도메인에서만 Orders와 Menus를 참조하고 있는데, 여러 Orders 와 Orders에 포함된 OrderMenus, 그리고 Menu 의 정보를 N+1 문제 없이 가져오는 방법에 대해 고민
- 해결한 방법
Order에 대해 먼저 페이징으로 조회(1번)
OrderId를 조건으로 OrderMenus를 주축으로 Orders와 Menus 페치조인!(1번)
=> 총 2번의 쿼리로 해결!

페치조인이 주로 OneToMany 에서만 봐서 양방향 관계에서만 사용되는줄 알았는데 페치조인은 단지 JPA가 조인을 하는 방법일뿐, 양방향, 단방향 관계가 크게 없다는 것을 새로 알았습니다 👍 

  <br/>

## 🔧 해결해야할 문제

@sinyoung0403 로그인 관련해서 오류가 나서 일단 로그인 부분은 주석처리하고 테스트했습니다! ( PR에는 되돌린 상태로 올렸습니다.)
문제 1. LoginRequestDto 생성자 문제
`Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of com.ddukbbegi.api.auth.dto.request.LoginRequestDto (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: REDACTED (StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION disabled); line: 2, column: 5]
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67) ~[jackson-databind-2.18.3.jar:2.18.3]
	at `
라고 뜨더라구요 이 문제는 저는 record로 수정해서 해결했습니다!

문제 2. 로그인이 계속 실패하는 문제
DB에 수동으로 이메일, 비밀번호를 저장해서 로그인 로직을 수행했는데, 로그인 실패 예외가 계속 발생했습니다.
저만 그런가요 ? ㅜㅜ 내일 회의 때 같이 논의해보면 좋을 것 같습니다!

  <br/>

<br/>
