### PR TITLE
[Feat] #26 : 가게 비즈니스 로직 구현 완료

### DIFF
--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.ddukbbegi.api.store.controller;
 
 import com.ddukbbegi.api.common.dto.PageResponseDto;
+import com.ddukbbegi.api.store.dto.response.StoreDetailResponseDto;
 import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
 import com.ddukbbegi.api.store.service.StoreService;
 import com.ddukbbegi.common.component.BaseResponse;
@@ -22,6 +23,13 @@ public class StoreController {
                                                                              @PageableDefault Pageable pageable) {
 
         PageResponseDto<StorePageItemResponseDto> response = storeService.getStores(name, pageable);
+        return BaseResponse.success(response, ResultCode.OK);
+    }
+
+    @GetMapping("/{storeId}")
+    public BaseResponse<StoreDetailResponseDto> getStore(@PathVariable Long storeId) {
+
+        StoreDetailResponseDto response = storeService.getStore(storeId);
         return BaseResponse.success(response, ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreOwnerController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreOwnerController.java
@@ -55,41 +55,46 @@ public class StoreOwnerController {
 
     @PatchMapping("/{storeId}/basic-info")
     public BaseResponse<Void> updateStoreBasicInfo(@PathVariable Long storeId,
-                                                   @RequestBody @Valid StoreUpdateBasicInfoRequestDto dto) {
+                                                   @RequestBody @Valid StoreUpdateBasicInfoRequestDto dto,
+                                                   @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        storeService.updateStoreBasicInfo(storeId, dto);
+        storeService.updateStoreBasicInfo(storeId, dto, customUserDetails.getUserId());
         return BaseResponse.success(ResultCode.OK);
     }
 
     @PatchMapping("/{storeId}/operation-info")
     public BaseResponse<Void> updateStoreOperationInfo(@PathVariable Long storeId,
-                                                       @RequestBody @Valid StoreUpdateOperationInfoRequestDto dto) {
+                                                       @RequestBody @Valid StoreUpdateOperationInfoRequestDto dto,
+                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        storeService.updateStoreOperationInfo(storeId, dto);
+        storeService.updateStoreOperationInfo(storeId, dto, customUserDetails.getUserId());
         return BaseResponse.success(ResultCode.OK);
     }
 
     @PatchMapping("/{storeId}/order-settings")
     public BaseResponse<Void> updateStoreOrderSettings(@PathVariable Long storeId,
-                                                       @RequestBody @Valid StoreUpdateOrderSettingsRequestDto dto) {
+                                                       @RequestBody @Valid StoreUpdateOrderSettingsRequestDto dto,
+                                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        storeService.updateStoreOrderSettings(storeId, dto);
+        storeService.updateStoreOrderSettings(storeId, dto, customUserDetails.getUserId());
         return BaseResponse.success(ResultCode.OK);
     }
 
     @PatchMapping("/{storeId}/temporarily-close")
     public BaseResponse<Void> updateTemporarilyClosed(@PathVariable Long storeId,
-                                                      @RequestBody @Valid StoreUpdateStatusRequest dto) {
+                                                      @RequestBody @Valid StoreUpdateStatusRequest dto,
+                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        storeService.updateTemporarilyClosed(storeId, dto);
+        storeService.updateTemporarilyClosed(storeId, dto, customUserDetails.getUserId());
         return BaseResponse.success(ResultCode.OK);
     }
 
     @PatchMapping("/{storeId}/permanently-close")
     public BaseResponse<Void> updatePermanentlyClosed(@PathVariable Long storeId,
-                                                      @RequestBody @Valid StoreUpdateStatusRequest dto) {
+                                                      @RequestBody @Valid StoreUpdateStatusRequest dto,
+                                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        storeService.updatePermanentlyClosed(storeId, dto);
+        storeService.updatePermanentlyClosed(storeId, dto, customUserDetails.getUserId());
         return BaseResponse.success(ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreOwnerController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreOwnerController.java
@@ -1,6 +1,7 @@
 package com.ddukbbegi.api.store.controller;
 
 import com.ddukbbegi.api.store.dto.request.*;
+import com.ddukbbegi.api.store.dto.response.OwnerStoreDetailResponseDto;
 import com.ddukbbegi.api.store.dto.response.OwnerStoreResponseDto;
 import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
 import com.ddukbbegi.api.store.dto.response.StoreRegisterAvailableResponseDto;
@@ -30,7 +31,7 @@ public class StoreOwnerController {
         return BaseResponse.success(response, ResultCode.CREATED);
     }
 
-    @GetMapping("/available")
+    @GetMapping("/me/available")
     public BaseResponse<StoreRegisterAvailableResponseDto> checkStoreRegistrationAvailability(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         StoreRegisterAvailableResponseDto response = storeService.checkStoreRegistrationAvailability(customUserDetails.getUserId());
@@ -41,6 +42,14 @@ public class StoreOwnerController {
     public BaseResponse<List<OwnerStoreResponseDto>> getOwnerStoreList(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         List<OwnerStoreResponseDto> response = storeService.getOwnerStoreList(customUserDetails.getUserId());
+        return BaseResponse.success(response, ResultCode.OK);
+    }
+
+    @GetMapping("/{storeId}")
+    public BaseResponse<OwnerStoreDetailResponseDto> getOwnerStoreDetail(@PathVariable(value = "storeId") Long storeId,
+                                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        OwnerStoreDetailResponseDto response = storeService.getOwnerStoreDetail(storeId, customUserDetails.getUserId());
         return BaseResponse.success(response, ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/controller/StoreOwnerController.java
+++ b/src/main/java/com/ddukbbegi/api/store/controller/StoreOwnerController.java
@@ -5,10 +5,12 @@ import com.ddukbbegi.api.store.dto.response.OwnerStoreResponseDto;
 import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
 import com.ddukbbegi.api.store.dto.response.StoreRegisterAvailableResponseDto;
 import com.ddukbbegi.api.store.service.StoreService;
+import com.ddukbbegi.common.auth.CustomUserDetails;
 import com.ddukbbegi.common.component.BaseResponse;
 import com.ddukbbegi.common.component.ResultCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,23 +23,24 @@ public class StoreOwnerController {
     private final StoreService storeService;
 
     @PostMapping
-    public BaseResponse<StoreIdResponseDto> registerStore(@RequestBody @Valid StoreRegisterRequestDto dto) {
+    public BaseResponse<StoreIdResponseDto> registerStore(@RequestBody @Valid StoreRegisterRequestDto dto,
+                                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        StoreIdResponseDto response = storeService.registerStore(dto);
+        StoreIdResponseDto response = storeService.registerStore(dto, customUserDetails.getUserId());
         return BaseResponse.success(response, ResultCode.CREATED);
     }
 
     @GetMapping("/available")
-    public BaseResponse<StoreRegisterAvailableResponseDto> checkStoreRegistrationAvailability() {
+    public BaseResponse<StoreRegisterAvailableResponseDto> checkStoreRegistrationAvailability(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        StoreRegisterAvailableResponseDto response = storeService.checkStoreRegistrationAvailability();
+        StoreRegisterAvailableResponseDto response = storeService.checkStoreRegistrationAvailability(customUserDetails.getUserId());
         return BaseResponse.success(response, ResultCode.OK);
     }
 
     @GetMapping
-    public BaseResponse<List<OwnerStoreResponseDto>> getOwnerStoreList() {
+    public BaseResponse<List<OwnerStoreResponseDto>> getOwnerStoreList(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        List<OwnerStoreResponseDto> response = storeService.getOwnerStoreList();
+        List<OwnerStoreResponseDto> response = storeService.getOwnerStoreList(customUserDetails.getUserId());
         return BaseResponse.success(response, ResultCode.OK);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreDetailResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+
+public record OwnerStoreDetailResponseDto(
+        Long storeId,
+        StoreBasicInfoResponse basicInfo,
+        StoreOperationInfoResponse operationInfo,
+        StoreOrderSettingsInfoResponse orderSettings,
+        StoreStatus status,
+        boolean isTemporarilyClosed,
+        boolean isPermanentlyClosed
+) {
+
+    public static OwnerStoreDetailResponseDto fromEntity(Store store) {
+        return new OwnerStoreDetailResponseDto(
+                store.getId(),
+                StoreBasicInfoResponse.fromEntity(store),
+                StoreOperationInfoResponse.fromEntity(store),
+                StoreOrderSettingsInfoResponse.fromEntity(store),
+                store.getStatus(),
+                store.isTemporarilyClosed(),
+                store.isPermanentlyClosed()
+        );
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreResponseDto.java
@@ -31,7 +31,7 @@ public record OwnerStoreResponseDto(
                 store.getName(),
                 store.getCategory().name(),
                 store.getStatus(),
-                TimeRangeFormatter.formatTimeRange(startTime, endTime),
+                TimeRangeFormatter.format(startTime, endTime),
                 store.isTemporarilyClosed(),
                 store.isPermanentlyClosed()
         );

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/OwnerStoreResponseDto.java
@@ -2,22 +2,36 @@ package com.ddukbbegi.api.store.dto.response;
 
 import com.ddukbbegi.api.store.entity.Store;
 import com.ddukbbegi.api.store.enums.StoreStatus;
+import com.ddukbbegi.api.store.util.TimeRangeFormatter;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record OwnerStoreResponseDto(
         Long storeId,
         String name,
         String category,
         StoreStatus status,
+
+        String breakTime,
         boolean isTemporarilyClosed,
         boolean isPermanentlyClosed
 ) {
 
     public static OwnerStoreResponseDto fromEntity(Store store) {
+        DayOfWeek dayOfWeek = LocalDateTime.now().getDayOfWeek();
+        boolean isWeekend = (dayOfWeek == DayOfWeek.SATURDAY) || (dayOfWeek == DayOfWeek.SUNDAY);
+
+        LocalTime startTime = isWeekend ? store.getWeekendBreakStartTime() : store.getWeekdayBreakStartTime();
+        LocalTime endTime = isWeekend ? store.getWeekendBreakEndTime() : store.getWeekdayBreakEndTime();
+
         return new OwnerStoreResponseDto(
                 store.getId(),
                 store.getName(),
                 store.getCategory().name(),
-                StoreStatus.OPEN,   // TODO: status 연산 로직 필요
+                store.getStatus(),
+                TimeRangeFormatter.formatTimeRange(startTime, endTime),
                 store.isTemporarilyClosed(),
                 store.isPermanentlyClosed()
         );

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreBasicInfoResponse.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreBasicInfoResponse.java
@@ -1,0 +1,21 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+
+public record StoreBasicInfoResponse(
+        String name,
+        String category,
+        String phoneNumber,
+        String description
+) {
+
+    public static StoreBasicInfoResponse fromEntity(Store store) {
+        return new StoreBasicInfoResponse(
+                store.getName(),
+                store.getCategory().name(),
+                store.getPhoneNumber(),
+                store.getDescription()
+        );
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreDetailResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+
+public record StoreDetailResponseDto(
+        Long storeId,
+        StoreBasicInfoResponse basicInfo,
+        StoreOperationInfoResponse operationInfo,
+        StoreOrderSettingsInfoResponse orderSettings,
+        StoreStatus status
+) {
+
+    public static StoreDetailResponseDto fromEntity(Store store) {
+        return new StoreDetailResponseDto(
+                store.getId(),
+                StoreBasicInfoResponse.fromEntity(store),
+                StoreOperationInfoResponse.fromEntity(store),
+                StoreOrderSettingsInfoResponse.fromEntity(store),
+                store.getStatus()
+        );
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreOperationInfoResponse.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreOperationInfoResponse.java
@@ -1,0 +1,27 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.DayOfWeek;
+import com.ddukbbegi.api.store.util.TimeRangeFormatter;
+
+import java.util.List;
+
+public record StoreOperationInfoResponse(
+        List<String> closedDays,
+        String weekdayWorkingTime,
+        String weekdayBreakTime,
+        String weekendWorkingTime,
+        String weekendBreakTime
+) {
+
+    public static StoreOperationInfoResponse fromEntity(Store store) {
+        return new StoreOperationInfoResponse(
+                store.getClosedDays().stream().map(DayOfWeek::name).toList(),
+                TimeRangeFormatter.format(store.getWeekdayWorkingStartTime(), store.getWeekdayWorkingEndTime()),
+                TimeRangeFormatter.format(store.getWeekdayBreakStartTime(), store.getWeekdayBreakEndTime()),
+                TimeRangeFormatter.format(store.getWeekendWorkingStartTime(), store.getWeekendWorkingEndTime()),
+                TimeRangeFormatter.format(store.getWeekendBreakStartTime(), store.getWeekendBreakEndTime())
+        );
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StoreOrderSettingsInfoResponse.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StoreOrderSettingsInfoResponse.java
@@ -1,0 +1,15 @@
+package com.ddukbbegi.api.store.dto.response;
+
+import com.ddukbbegi.api.store.entity.Store;
+
+public record StoreOrderSettingsInfoResponse(
+        Integer minDeliveryPrice,
+        Integer deliveryTip
+) {
+    public static StoreOrderSettingsInfoResponse fromEntity(Store store) {
+        return new StoreOrderSettingsInfoResponse(
+                store.getMinDeliveryPrice(),
+                store.getDeliveryTip()
+        );
+    }
+}

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StorePageItemResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StorePageItemResponseDto.java
@@ -1,13 +1,15 @@
 package com.ddukbbegi.api.store.dto.response;
 
 import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
 
 public record StorePageItemResponseDto(
         String name,
         String description,
         String storeCategory,
         Integer minDeliveryPrice,
-        Integer deliveryTip
+        Integer deliveryTip,
+        StoreStatus status
 ) {
 
     public static StorePageItemResponseDto fromEntity(Store store) {
@@ -17,7 +19,8 @@ public record StorePageItemResponseDto(
                 store.getDescription(),
                 store.getCategory().name(),
                 store.getMinDeliveryPrice(),
-                store.getDeliveryTip()
+                store.getDeliveryTip(),
+                store.getStatus()
         );
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/entity/Store.java
+++ b/src/main/java/com/ddukbbegi/api/store/entity/Store.java
@@ -4,6 +4,7 @@ import com.ddukbbegi.api.common.entity.BaseUserEntity;
 import com.ddukbbegi.api.store.enums.DayOfWeek;
 import com.ddukbbegi.api.store.enums.DayOfWeekListConverter;
 import com.ddukbbegi.api.store.enums.StoreCategory;
+import com.ddukbbegi.api.store.enums.StoreStatus;
 import com.ddukbbegi.api.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -66,6 +67,10 @@ public class Store extends BaseUserEntity {
 
     @Column(nullable = false)
     private boolean isPermanentlyClosed = false;    // 폐업 여부
+    
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StoreStatus status = StoreStatus.CLOSED;     // 가게 영업 상태. 10분마다 업데이트 됨
 
     @Builder
     public Store(User user,
@@ -143,6 +148,10 @@ public class Store extends BaseUserEntity {
 
     public void updatePermanentlyClosed(boolean status) {
         this.isPermanentlyClosed = status;
+    }
+
+    public void updateStatus(StoreStatus status) {
+        this.status = status;
     }
 
 }

--- a/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
@@ -7,7 +7,7 @@ public enum StoreStatus {
     OPEN,                   // 정상 영업 중
     CLOSED,                 // 영업 종료
     BREAK,                  // 휴게 시간
-    TEMPORARILY_CLOSED,     // 임시 휴업
+    TEMPORARILY_CLOSED,     // 임시 휴업 (사장이 직접 ON/OFF)
     PERMANENTLY_CLOSED;     // 폐업
 
     public static StoreStatus fromString(String name) {

--- a/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
+++ b/src/main/java/com/ddukbbegi/api/store/enums/StoreStatus.java
@@ -7,7 +7,7 @@ public enum StoreStatus {
     OPEN,                   // 정상 영업 중
     CLOSED,                 // 영업 종료
     BREAK,                  // 휴게 시간
-    TEMPORARILY_CLOSED,     // 임시 휴업 (사장이 직접 ON/OFF)
+    TEMPORARILY_CLOSED,     // 영업 임시 중지 (사장이 직접 ON/OFF)
     PERMANENTLY_CLOSED;     // 폐업
 
     public static StoreStatus fromString(String name) {

--- a/src/main/java/com/ddukbbegi/api/store/repository/StoreRepository.java
+++ b/src/main/java/com/ddukbbegi/api/store/repository/StoreRepository.java
@@ -14,7 +14,15 @@ public interface StoreRepository extends BaseRepository<Store, Long> {
     List<Store> findAllByUser_Id(Long userId);
 
     @EntityGraph(attributePaths = { "user" })
-    @Query("SELECT s FROM Store s WHERE s.name LIKE :name")
+    @Query("""
+        SELECT s
+        FROM Store s
+        WHERE
+            s.name LIKE :name
+            AND s.status != 'PERMANENTLY_CLOSED'
+        ORDER BY
+            CASE WHEN s.status = 'OPEN' THEN 0 ELSE 1 END
+    """)
     Page<Store> findAllOpenedStoreByName(String name, Pageable pageable);
 
     @Query("SELECT COUNT(*) < 3 FROM Store s WHERE s.user.id = :userId AND s.isPermanentlyClosed IS FALSE")

--- a/src/main/java/com/ddukbbegi/api/store/scheduler/StoreStatusScheduler.java
+++ b/src/main/java/com/ddukbbegi/api/store/scheduler/StoreStatusScheduler.java
@@ -1,0 +1,48 @@
+package com.ddukbbegi.api.store.scheduler;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import com.ddukbbegi.api.store.repository.StoreRepository;
+import com.ddukbbegi.api.store.service.StoreStatusResolveService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class StoreStatusScheduler {
+
+    private final StoreRepository storeRepository;
+    private final StoreStatusResolveService storeStatusResolveService;
+
+    @Scheduled(cron = "0 */10 * * * *")     // 매 10분마다 실행
+    @Transactional
+    public void updateStoreStatuses() {
+
+        List<Store> stores = storeRepository.findAll();
+        long updatedRows = 0L;
+
+        LocalDateTime now = LocalDateTime.now();
+        for (Store store : stores) {
+            StoreStatus newStatus = storeStatusResolveService.resolveStoreStatus(store, now);
+
+            if (!Objects.equals(store.getStatus(), newStatus)) {
+                store.updateStatus(newStatus);
+                updatedRows++;
+            }
+        }
+
+        log.info("[{}] 가게 status 업데이트 완료: {} 개 처리",
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                updatedRows);
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -2,10 +2,7 @@ package com.ddukbbegi.api.store.service;
 
 import com.ddukbbegi.api.common.dto.PageResponseDto;
 import com.ddukbbegi.api.store.dto.request.*;
-import com.ddukbbegi.api.store.dto.response.OwnerStoreResponseDto;
-import com.ddukbbegi.api.store.dto.response.StoreIdResponseDto;
-import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
-import com.ddukbbegi.api.store.dto.response.StoreRegisterAvailableResponseDto;
+import com.ddukbbegi.api.store.dto.response.*;
 import com.ddukbbegi.api.store.entity.Store;
 import com.ddukbbegi.api.store.repository.StoreRepository;
 import com.ddukbbegi.api.user.entity.User;
@@ -58,11 +55,24 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
+    public OwnerStoreDetailResponseDto getOwnerStoreDetail(Long storeId) {
+
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        return OwnerStoreDetailResponseDto.fromEntity(store);
+    }
+
+    @Transactional(readOnly = true)
     public PageResponseDto<StorePageItemResponseDto> getStores(String name, Pageable pageable) {
 
         Page<StorePageItemResponseDto> result = storeRepository.findAllOpenedStoreByName("%" + name + "%", pageable)
                 .map(StorePageItemResponseDto::fromEntity);
         return PageResponseDto.toDto(result);
+    }
+
+    @Transactional(readOnly = true)
+    public StoreDetailResponseDto getStore() {
+
+        return null;
     }
 
     @Transactional

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -55,9 +56,14 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public OwnerStoreDetailResponseDto getOwnerStoreDetail(Long storeId) {
-
+    public OwnerStoreDetailResponseDto getOwnerStoreDetail(Long storeId, Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
         Store store = storeRepository.findByIdOrElseThrow(storeId);
+
+        if (!Objects.equals(store.getUser().getId(), user.getId())) {
+            throw new BusinessException(ResultCode.STORE_FORBIDDEN_ACCESS);
+        }
+
         return OwnerStoreDetailResponseDto.fromEntity(store);
     }
 
@@ -70,9 +76,10 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public StoreDetailResponseDto getStore() {
+    public StoreDetailResponseDto getStore(Long storeId) {
 
-        return null;
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        return StoreDetailResponseDto.fromEntity(store);
     }
 
     @Transactional

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -28,10 +28,10 @@ public class StoreService {
     private final UserRepository userRepository;
 
     @Transactional
-    public StoreIdResponseDto registerStore(StoreRegisterRequestDto dto) {
+    public StoreIdResponseDto registerStore(StoreRegisterRequestDto dto, Long userId) {
 
-        User user = userRepository.findByIdOrElseThrow(1L); // TODO: user 연동
-        if (!storeRepository.isStoreRegistrationAvailable(1L)) {    // TODO: user 연동
+        User user = userRepository.findByIdOrElseThrow(userId);
+        if (!storeRepository.isStoreRegistrationAvailable(userId)) {
             throw new BusinessException(ResultCode.STORE_LIMIT_EXCEEDED);
         }
 
@@ -42,16 +42,16 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public StoreRegisterAvailableResponseDto checkStoreRegistrationAvailability() {
+    public StoreRegisterAvailableResponseDto checkStoreRegistrationAvailability(Long userId) {
 
-        boolean available = storeRepository.isStoreRegistrationAvailable(1L); // TODO: user 연동
+        boolean available = storeRepository.isStoreRegistrationAvailable(userId);
         return StoreRegisterAvailableResponseDto.of(available);
     }
 
     @Transactional(readOnly = true)
-    public List<OwnerStoreResponseDto> getOwnerStoreList() {
+    public List<OwnerStoreResponseDto> getOwnerStoreList(Long userId) {
 
-        List<Store> storeList = storeRepository.findAllByUser_Id(1L);   // TODO: user 연동
+        List<Store> storeList = storeRepository.findAllByUser_Id(userId);
         return storeList.stream()
                 .map(OwnerStoreResponseDto::fromEntity)
                 .toList();

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreStatusResolveService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreStatusResolveService.java
@@ -1,0 +1,54 @@
+package com.ddukbbegi.api.store.service;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Service
+public class StoreStatusResolveService {
+
+    public StoreStatus resolveStoreStatus(Store store, LocalDateTime now) {
+        
+        if (store.isPermanentlyClosed()) {
+            return StoreStatus.PERMANENTLY_CLOSED;
+        }
+
+        if (store.isTemporarilyClosed()) {
+            return StoreStatus.TEMPORARILY_CLOSED;
+        }
+
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+        LocalTime time = now.toLocalTime();
+        boolean isWeekend = (dayOfWeek == DayOfWeek.SATURDAY) || (dayOfWeek == DayOfWeek.SUNDAY);
+
+        LocalTime openTime = isWeekend ? store.getWeekendWorkingStartTime() : store.getWeekdayWorkingStartTime();
+        LocalTime closeTime = isWeekend ? store.getWeekendWorkingEndTime() : store.getWeekdayWorkingEndTime();
+        LocalTime breakStart = isWeekend ? store.getWeekendBreakStartTime() : store.getWeekdayBreakStartTime();
+        LocalTime breakEnd = isWeekend ? store.getWeekendBreakEndTime() : store.getWeekdayBreakEndTime();
+
+
+        if (isWithin(time, breakStart, breakEnd)) {
+            return StoreStatus.BREAK;
+        }
+
+        if (isWithin(time, openTime, closeTime)) {
+            return StoreStatus.OPEN;
+        }
+
+        return StoreStatus.CLOSED;
+    }
+
+    private boolean isWithin(LocalTime now, LocalTime start, LocalTime end) {
+        if (start.isBefore(end)) {
+            return now.isAfter(start) && now.isBefore(end);
+        } else {
+            // 자정을 넘긴 시간 범위
+            return now.isAfter(start) || now.isBefore(end);
+        }
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/util/TimeRangeFormatter.java
+++ b/src/main/java/com/ddukbbegi/api/store/util/TimeRangeFormatter.java
@@ -1,0 +1,14 @@
+package com.ddukbbegi.api.store.util;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeRangeFormatter {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static String formatTimeRange(LocalTime startTime, LocalTime endTime) {
+        return startTime.format(TIME_FORMATTER) + "-" + endTime.format(TIME_FORMATTER);
+    }
+
+}

--- a/src/main/java/com/ddukbbegi/api/store/util/TimeRangeFormatter.java
+++ b/src/main/java/com/ddukbbegi/api/store/util/TimeRangeFormatter.java
@@ -7,7 +7,7 @@ public class TimeRangeFormatter {
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-    public static String formatTimeRange(LocalTime startTime, LocalTime endTime) {
+    public static String format(LocalTime startTime, LocalTime endTime) {
         return startTime.format(TIME_FORMATTER) + "-" + endTime.format(TIME_FORMATTER);
     }
 

--- a/src/main/java/com/ddukbbegi/common/component/ResultCode.java
+++ b/src/main/java/com/ddukbbegi/common/component/ResultCode.java
@@ -28,6 +28,7 @@ public enum ResultCode {
 
     /* 가게 도메인 */
     STORE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "E301", "가게 등록 가능 개수를 초과했습니다. 최대 3개까지만 등록할 수 있습니다."),
+    STORE_FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "E301", "해당 가게에 접근할 권한이 없습니다."),
 
     /* 주문 도메인 */
     CONTAIN_DIFFERENT_STORE_MENU(HttpStatus.BAD_REQUEST,"E201","서로 다른 가게의 메뉴가 포함되어 있습니다."),

--- a/src/main/java/com/ddukbbegi/common/config/AuditorAwareImpl.java
+++ b/src/main/java/com/ddukbbegi/common/config/AuditorAwareImpl.java
@@ -2,6 +2,7 @@ package com.ddukbbegi.common.config;
 
 import com.ddukbbegi.common.auth.CustomUserDetails;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 
@@ -12,8 +13,14 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
     @Override
     public Optional<Long> getCurrentAuditor() {
 
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+        // 스케쥴러 등 인증 주체가 없을 경우
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
         if (principal instanceof CustomUserDetails) {
             Long userId = ((CustomUserDetails) principal).getUserId();
             return Optional.of(userId);

--- a/src/main/java/com/ddukbbegi/common/config/SchedulerConfig.java
+++ b/src/main/java/com/ddukbbegi/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.ddukbbegi.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/test/java/com/ddukbbegi/api/store/scheduler/StoreStatusSchedulerTest.java
+++ b/src/test/java/com/ddukbbegi/api/store/scheduler/StoreStatusSchedulerTest.java
@@ -1,0 +1,62 @@
+package com.ddukbbegi.api.store.scheduler;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import com.ddukbbegi.api.store.repository.StoreRepository;
+import com.ddukbbegi.api.store.service.StoreStatusResolveService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StoreStatusSchedulerTest {
+
+    @InjectMocks private StoreStatusScheduler storeStatusScheduler;
+
+    @Mock private StoreRepository storeRepository;
+    @Mock private StoreStatusResolveService storeStatusResolveService;
+
+    @Test
+    @DisplayName("상태가 변경된 경우 updateStatus가 호출된다")
+    void givenChangedStatus_whenUpdateStoreStatuses_thenStatusIsUpdated() {
+        // given
+        Store store = mock(Store.class);
+
+        given(storeRepository.findAll()).willReturn(List.of(store));
+        given(store.getStatus()).willReturn(StoreStatus.CLOSED);
+        given(storeStatusResolveService.resolveStoreStatus(any(), any())).willReturn(StoreStatus.OPEN);
+
+        // when
+        storeStatusScheduler.updateStoreStatuses();
+
+        // then
+        verify(store).updateStatus(StoreStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("상태가 동일하면 updateStatus가 호출되지 않는다")
+    void givenUnchangedStatus_whenUpdateStoreStatuses_thenStatusIsNotUpdated() {
+        // given
+        Store store = mock(Store.class);
+
+        given(storeRepository.findAll()).willReturn(List.of(store));
+        given(store.getStatus()).willReturn(StoreStatus.OPEN);
+        given(storeStatusResolveService.resolveStoreStatus(any(), any())).willReturn(StoreStatus.OPEN);
+
+        // when
+        storeStatusScheduler.updateStoreStatuses();
+
+        // then
+        verify(store, never()).updateStatus(any());
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/api/store/service/StoreStatusResolveServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/store/service/StoreStatusResolveServiceTest.java
@@ -1,0 +1,64 @@
+package com.ddukbbegi.api.store.service;
+
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StoreStatusResolveServiceTest {
+
+    private final StoreStatusResolveService service = new StoreStatusResolveService();
+
+    @ParameterizedTest(name = "{index}: 현재시간 {1} => 예상 상태: {2}")
+    @MethodSource("provideStoreStatusTestCases")
+    @DisplayName("가게 상태 판단 테스트")
+    void resolveStoreStatus_worksAsExpected(Store store, LocalDateTime now, StoreStatus expectedStatus) {
+        StoreStatus result = service.resolveStoreStatus(store, now);
+        assertThat(result).isEqualTo(expectedStatus);
+    }
+
+    private static Stream<Arguments> provideStoreStatusTestCases() {
+        return Stream.of(
+                // OPEN 시간 (평일)
+                Arguments.of(mockStore(false, false), LocalDateTime.of(2025, 4, 24, 11, 0), StoreStatus.OPEN),
+                // CLOSED (영업 종료 후)
+                Arguments.of(mockStore(false, false), LocalDateTime.of(2025, 4, 24, 23, 0), StoreStatus.CLOSED),
+                // BREAK 시간
+                Arguments.of(mockStore(false, false), LocalDateTime.of(2025, 4, 24, 13, 30), StoreStatus.BREAK),
+                // 자정 넘는 OPEN (01:00)
+                Arguments.of(mockStore(false, false), LocalDateTime.of(2025, 4, 27, 1, 0), StoreStatus.OPEN),
+                // PERMANENTLY_CLOSED
+                Arguments.of(mockStore(true, false), LocalDateTime.of(2025, 4, 24, 12, 0), StoreStatus.PERMANENTLY_CLOSED),
+                // TEMPORARILY_CLOSED
+                Arguments.of(mockStore(false, true), LocalDateTime.of(2025, 4, 24, 12, 0), StoreStatus.TEMPORARILY_CLOSED)
+        );
+    }
+
+    private static Store mockStore(boolean isPermanentlyClosed, boolean isTemporarilyClosed) {
+        return new Store() {
+            @Override public boolean isPermanentlyClosed() { return isPermanentlyClosed; }
+            @Override public boolean isTemporarilyClosed() { return isTemporarilyClosed; }
+
+            // 평일 (10:00-22:00, 13:00-14:00)
+            @Override public LocalTime getWeekdayWorkingStartTime() { return LocalTime.of(10, 0); }
+            @Override public LocalTime getWeekdayWorkingEndTime() { return LocalTime.of(22, 0); }
+            @Override public LocalTime getWeekdayBreakStartTime() { return LocalTime.of(13, 0); }
+            @Override public LocalTime getWeekdayBreakEndTime() { return LocalTime.of(14, 0); }
+
+            // 주말 - 자정 넘는 영업 (23:00-02:00, 00:30-01:00)
+            @Override public LocalTime getWeekendWorkingStartTime() { return LocalTime.of(23, 0); }
+            @Override public LocalTime getWeekendWorkingEndTime() { return LocalTime.of(2, 0); }
+            @Override public LocalTime getWeekendBreakStartTime() { return LocalTime.of(0, 30); }
+            @Override public LocalTime getWeekendBreakEndTime() { return LocalTime.of(1, 0); }
+        };
+    }
+
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 주기적으로 가게 status 업데이트
  - 가게의 영업 상태는 영업 시간, 휴게 시간, 영업임시중지 등을 고려해야 한다.
  - 스프링 스케쥴러를 사용해 10분마다 모든 가게의 상태를 업데이트한다.
- 비즈니스 로직에서 유저 정보 연동
- 가게 목록 조회 데이터 및 구조 수정
- 가게 단일 조회 기능 구현
- 가게 정보 수정 시 권한 체크

## ➕ 트러블 슈팅

- 스케쥴러에서 DB 수정 시 AuditorAware에서 NPE 발생
  - 스케쥴러는 HTTP 요청으로 들어오는게 아니라 내부 스레드에서 동작한다.
  - 때문에 SecurityContext 등에 인증 정보가 저장되지 않음(null)
  - 이와 관련된 예외 처리를 추가했다.

## 🔧 해결해야할 문제

- Entity와 DTO에 필드가 많아 변환해주는 코드(toEntity, fromEntity 등)가 많아서 이를 개선해야 한다.

## Ref
- #22 

This closes #26 
