### PR TITLE
[Feat] #71 : Order 도메인 관련 동시성 제어

### DIFF
--- a/src/main/java/com/ddukbbegi/api/menu/entity/Menu.java
+++ b/src/main/java/com/ddukbbegi/api/menu/entity/Menu.java
@@ -70,4 +70,7 @@ public class Menu {
 		this.category = category;
 	}
 
+	public void delete() {
+		this.status = MenuStatus.DELETED;
+	}
 }

--- a/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
@@ -24,8 +24,7 @@ public interface MenuRepository extends BaseRepository<Menu, Long> {
 	@Query("UPDATE Menu m SET m.status = :status WHERE m.id = :id")
 	void updateMenuStatusById(@Param("id") long id, @Param("status") MenuStatus status);
 
-	@Query("SELECT m FROM Menu m WHERE m.id IN :menuIds AND m.status != 'DELETED'")
-	List<Menu> findAllByIdInAndNotDeleted(@Param("menuIds") List<Long> menuIds);
+	List<Menu> findAllByIdInAndStatusNot(List<Long> ids, MenuStatus menuStatus);
 
 	// @Query("SELECT COUNT(s) > 0 FROM Store s WHERE s.id = :storeId AND s.user.id = :userId")
 	// boolean checkOwnerTest(@Param("storeId") Long storeId, @Param("userId") Long userId);

--- a/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ddukbbegi/api/menu/repository/MenuRepository.java
@@ -24,7 +24,8 @@ public interface MenuRepository extends BaseRepository<Menu, Long> {
 	@Query("UPDATE Menu m SET m.status = :status WHERE m.id = :id")
 	void updateMenuStatusById(@Param("id") long id, @Param("status") MenuStatus status);
 
-	List<Menu> findAllByIdInAndIsDeletedFalse(List<Long> menuIds);
+	@Query("SELECT m FROM Menu m WHERE m.id IN :menuIds AND m.status != 'DELETED'")
+	List<Menu> findAllByIdInAndNotDeleted(@Param("menuIds") List<Long> menuIds);
 
 	// @Query("SELECT COUNT(s) > 0 FROM Store s WHERE s.id = :storeId AND s.user.id = :userId")
 	// boolean checkOwnerTest(@Param("storeId") Long storeId, @Param("userId") Long userId);

--- a/src/main/java/com/ddukbbegi/api/order/dto/request/OrderCreateRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/order/dto/request/OrderCreateRequestDto.java
@@ -10,7 +10,8 @@ public record OrderCreateRequestDto(
         @NotEmpty(message = "메뉴 목록은 비어 있을 수 없습니다.")
         List<@Valid MenuOrderDto> menus,
 
-        String requestComment
+        String requestComment,
+        String requestId
 
 ) {
     public record MenuOrderDto(

--- a/src/main/java/com/ddukbbegi/api/order/entity/Order.java
+++ b/src/main/java/com/ddukbbegi/api/order/entity/Order.java
@@ -29,6 +29,9 @@ public class Order extends BaseUserEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Store store;
 
+    @Version
+    private Long version;
+
     @NotNull
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;

--- a/src/main/java/com/ddukbbegi/api/order/entity/Order.java
+++ b/src/main/java/com/ddukbbegi/api/order/entity/Order.java
@@ -36,12 +36,16 @@ public class Order extends BaseUserEntity {
     @Nullable
     private String requestComment;
 
+    @Column(name = "request_id", nullable = false, unique = true)
+    private String requestId;
+
     @Builder
-    public Order(User user, Store store, @Nullable String requestComment) {
+    public Order(User user, Store store, @Nullable String requestComment, String requestId) {
         this.user = user;
         this.store = store;
         this.orderStatus = OrderStatus.WAITING;
         this.requestComment = requestComment;
+        this.requestId = requestId;
     }
 
     public void cancel() {

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -36,6 +36,14 @@ public interface OrderRepository extends BaseRepository<Order, Long> {
 
     boolean existsByRequestId(String requestId);
 
+    @Query("SELECT o FROM Order o JOIN FETCH o.store WHERE o.id = :orderId")
+    Optional<Order> findByIdWithStore(@Param("orderId") Long orderId);
+
+    default Order findByIdWithStoreOrElseThrow(Long orderId) {
+        return findByIdWithStore(orderId)
+                .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
+    }
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
     @Query("SELECT o FROM Order o JOIN FETCH o.store WHERE o.id = :orderId")

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -39,7 +39,7 @@ public interface OrderRepository extends BaseRepository<Order, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
     @Query("SELECT o FROM Order o JOIN FETCH o.store WHERE o.id = :orderId")
-    Optional<Order> findByIdWithStoreForUpdate(Long orderId);
+    Optional<Order> findByIdWithStoreForUpdate(@Param(value = "orderId") Long orderId);
 
     default Order findByIdWithStoreForUpdateOrElseThrow(Long orderId) {
         return findByIdWithStoreForUpdate(orderId)
@@ -49,7 +49,7 @@ public interface OrderRepository extends BaseRepository<Order, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
     @Query("SELECT o FROM Order o WHERE o.id = :orderId")
-    Optional<Order> findByIdForUpdate(long orderId);
+    Optional<Order> findByIdForUpdate(@Param(value = "orderId") long orderId);
 
     default Order findByIdForUpdateOrElseThrow(Long orderId) {
         return findByIdForUpdate(orderId)

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -3,9 +3,13 @@ package com.ddukbbegi.api.order.repository;
 import com.ddukbbegi.api.common.repository.BaseRepository;
 import com.ddukbbegi.api.order.entity.Order;
 import com.ddukbbegi.common.exception.BusinessException;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -30,13 +34,25 @@ public interface OrderRepository extends BaseRepository<Order, Long> {
     )
     Page<Order> findAllByStoreId(@Param(value = "storeId") long storeId, Pageable pageable);
 
-    @Query("SELECT o FROM Order o JOIN FETCH o.store WHERE o.id = :orderId")
-    Optional<Order> findByIdWithStore(@Param("orderId") Long orderId);
+    boolean existsByRequestId(String requestId);
 
-    default Order findByIdWithStoreOrElseThrow(Long orderId) {
-        return findByIdWithStore(orderId)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    @Query("SELECT o FROM Order o JOIN FETCH o.store WHERE o.id = :orderId")
+    Optional<Order> findByIdWithStoreForUpdate(Long orderId);
+
+    default Order findByIdWithStoreForUpdateOrElseThrow(Long orderId) {
+        return findByIdWithStoreForUpdate(orderId)
                 .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
     }
 
-    boolean existsByRequestId(String requestId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    @Query("SELECT o FROM Order o WHERE o.id = :orderId")
+    Optional<Order> findByIdForUpdate(long orderId);
+
+    default Order findByIdForUpdateOrElseThrow(Long orderId) {
+        return findByIdForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddukbbegi/api/order/repository/OrderRepository.java
@@ -37,4 +37,6 @@ public interface OrderRepository extends BaseRepository<Order, Long> {
         return findByIdWithStore(orderId)
                 .orElseThrow(() -> new BusinessException(ORDER_NOT_FOUND));
     }
+
+    boolean existsByRequestId(String requestId);
 }

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -153,21 +153,19 @@ public class OrderService {
                 OrderHistoryUserResponseDto.from(
                         order,
                         orderMenuMap.getOrDefault(order.getId(), List.of()),
-                        false
-                        //todo: Review에 Order 참조되면 주석 해제
-                        //isReviewed(orderIds, order)
+                        isReviewed(orderIds, order)
                 )
         );
 
         return PageResponseDto.toDto(result);
     }
 
-//    private boolean isReviewed(List<Long> orderIds, Order order) {
-//        List<Long> reviewedOrderIds = reviewRepository.findReviewedOrderIds(orderIds);
-//        Set<Long> reviewedOrderIdSet = new HashSet<>(reviewedOrderIds);
-//
-//        return reviewedOrderIdSet.contains(order.getId());
-//    }
+    private boolean isReviewed(List<Long> orderIds, Order order) {
+        List<Long> reviewedOrderIds = reviewRepository.findReviewedOrderIds(orderIds);
+        Set<Long> reviewedOrderIdSet = new HashSet<>(reviewedOrderIds);
+
+        return reviewedOrderIdSet.contains(order.getId());
+    }
 
     @Transactional(readOnly = true)
     public PageResponseDto<OrderHistoryOwnerResponseDto> getOrdersForOwner(long storeId, Pageable pageable) {

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -2,6 +2,7 @@ package com.ddukbbegi.api.order.service;
 
 import com.ddukbbegi.api.common.dto.PageResponseDto;
 import com.ddukbbegi.api.menu.entity.Menu;
+import com.ddukbbegi.api.menu.enums.MenuStatus;
 import com.ddukbbegi.api.menu.repository.MenuRepository;
 import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
 import com.ddukbbegi.api.order.dto.response.OrderCreateResponseDto;
@@ -59,7 +60,7 @@ public class OrderService {
                 .map(OrderCreateRequestDto.MenuOrderDto::menuId)
                 .toList();
 
-        List<Menu> menus = menuRepository.findAllByIdInAndNotDeleted(menuIds);
+        List<Menu> menus = menuRepository.findAllByIdInAndStatusNot(menuIds, MenuStatus.DELETED);
         checkIsAllNotDeleted(menuIds.size(),menus.size());
 
         Store store = menus.get(0).getStore();

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -132,7 +132,7 @@ public class OrderService {
 
     private void checkIsAllSameStore(List<Menu> menus,long storeId) {
         boolean allSameStore = menus.stream()
-                .allMatch(menu -> menu.getStore().getId()==(storeId));
+                .allMatch(menu -> menu.getStoreId()==(storeId));
         if (!allSameStore) {
             throw new BusinessException(ResultCode.CONTAIN_DIFFERENT_STORE_MENU);
         }

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -194,7 +194,7 @@ public class OrderService {
 
     @Transactional
     public void cancelOrder(long orderId, long userId) {
-        Order order = orderRepository.findByIdForUpdateOrElseThrow(orderId);
+        Order order = orderRepository.findByIdOrElseThrow(orderId);
         checkOrderIsUserOrder(order, userId);
         checkCancelIsAvailable(order);
 
@@ -216,7 +216,7 @@ public class OrderService {
 
     @Transactional
     public void updateOrderStatus(Long orderId, OrderStatus newStatus, Long ownerId) {
-        Order order = orderRepository.findByIdWithStoreForUpdateOrElseThrow(orderId);
+        Order order = orderRepository.findByIdWithStoreOrElseThrow(orderId);
         checkOwnerIsRight(order, ownerId);
 
         OrderStatus currentStatus = order.getOrderStatus();

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -60,14 +60,11 @@ public class OrderService {
                 .map(OrderCreateRequestDto.MenuOrderDto::menuId)
                 .toList();
 
-        List<Menu> menus = menuRepository.findAllByIdInAndIsDeletedFalse(menuIds);
+        List<Menu> menus = menuRepository.findAllByIdInAndNotDeleted(menuIds);
         checkIsAllNotDeleted(menuIds.size(),menus.size());
 
-        // long storeId = menus.get(0).getStoreId();
-        long storeId = 1L;
-
-        checkIsAllSameStore(menus, storeId);
-        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        Store store = menus.get(0).getStore();
+        checkIsAllSameStore(menus, store.getId());
 
         LocalTime now = now();
         checkStoreIsWorking(now,store);
@@ -132,7 +129,7 @@ public class OrderService {
 
     private void checkIsAllSameStore(List<Menu> menus,long storeId) {
         boolean allSameStore = menus.stream()
-                .allMatch(menu -> menu.getStoreId()==(storeId));
+                .allMatch(menu -> menu.getStore().getId()==(storeId));
         if (!allSameStore) {
             throw new BusinessException(ResultCode.CONTAIN_DIFFERENT_STORE_MENU);
         }

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -194,7 +194,7 @@ public class OrderService {
 
     @Transactional
     public void cancelOrder(long orderId, long userId) {
-        Order order = orderRepository.findByIdOrElseThrow(orderId);
+        Order order = orderRepository.findByIdForUpdateOrElseThrow(orderId);
         checkOrderIsUserOrder(order, userId);
         checkCancelIsAvailable(order);
 
@@ -216,7 +216,7 @@ public class OrderService {
 
     @Transactional
     public void updateOrderStatus(Long orderId, OrderStatus newStatus, Long ownerId) {
-        Order order = orderRepository.findByIdWithStoreOrElseThrow(orderId);
+        Order order = orderRepository.findByIdWithStoreForUpdateOrElseThrow(orderId);
         checkOwnerIsRight(order, ownerId);
 
         OrderStatus currentStatus = order.getOrderStatus();

--- a/src/main/java/com/ddukbbegi/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ddukbbegi/api/review/repository/ReviewRepository.java
@@ -18,22 +18,17 @@ import java.util.Optional;
 
 public interface ReviewRepository extends BaseRepository<Review, Long> {
 
-
     Page<Review> findAllByUser(User user, Pageable pageable);
 
     @Query("select r from Review r join fetch r.user where r.id = :reviewId")
     Optional<Review> findByIdWithUser(@Param("reviewId") Long reviewId);
 
-
-    // todo: 리뷰 엔티티에 주문 참조되면 주석 해제
-//    @Query("SELECT r.order.id FROM Review r WHERE r.order.id IN :orderIds")
-//    List<Long> findReviewedOrderIds(@Param("orderIds") List<Long> orderIds);
-
+    @Query("SELECT r.order.id FROM Review r WHERE r.order.id IN :orderIds")
+    List<Long> findReviewedOrderIds(@Param("orderIds") List<Long> orderIds);
 
     default Review findReviewByIdWithUser(Long reviewId){
         return findByIdWithUser(reviewId).orElseThrow(()->new BusinessException(ResultCode.NOT_FOUND));
     }
     Page<Review> findByOrder_Store(@NotNull Store orderStore, Pageable pageable);
-
 
 }

--- a/src/main/java/com/ddukbbegi/common/component/ResultCode.java
+++ b/src/main/java/com/ddukbbegi/common/component/ResultCode.java
@@ -46,7 +46,6 @@ public enum ResultCode {
     ORDER_ALREADY_TERMINATED(HttpStatus.BAD_REQUEST,"E208" ,"이미 종료된 주문입니다." ),
     STORE_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "E209", "본인 가게의 주문이 아닙니다."),
     ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST,"E210", "존재하지 않는 주문입니다.");
-    UNDER_MIN_DELIVERY_PRICE(HttpStatus.BAD_REQUEST, "E204", "최소 주문 금액이 충족되지 않았습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ddukbbegi/common/component/ResultCode.java
+++ b/src/main/java/com/ddukbbegi/common/component/ResultCode.java
@@ -45,7 +45,8 @@ public enum ResultCode {
     ORDER_STATUS_FLOW_INVALID(HttpStatus.BAD_REQUEST, "E207", "현재 주문 단계의 다음 상태로만 변경이 가능합니다."),
     ORDER_ALREADY_TERMINATED(HttpStatus.BAD_REQUEST,"E208" ,"이미 종료된 주문입니다." ),
     STORE_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "E209", "본인 가게의 주문이 아닙니다."),
-    ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST,"E210", "존재하지 않는 주문입니다.");
+    ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST,"E210", "존재하지 않는 주문입니다."),
+    DUPLICATE_REQUEST_ID(HttpStatus.BAD_REQUEST, "E211", "이미 요청된 주문입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderConcurrencyTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderConcurrencyTest.java
@@ -1,0 +1,129 @@
+package com.ddukbbegi.api.order.service;
+
+import com.ddukbbegi.api.menu.entity.Menu;
+import com.ddukbbegi.api.menu.enums.MenuStatus;
+import com.ddukbbegi.api.menu.repository.MenuRepository;
+import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
+import com.ddukbbegi.api.order.repository.OrderRepository;
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreCategory;
+import com.ddukbbegi.api.store.repository.StoreRepository;
+import com.ddukbbegi.api.user.entity.User;
+import com.ddukbbegi.api.user.enums.UserRole;
+import com.ddukbbegi.api.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.*;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class OrderConcurrencyTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Autowired
+    private OrderService orderService;
+
+    private User user;
+
+    private User owner;
+
+    private Store store;
+
+    private String uuid;
+
+    private Menu menu;
+
+    private int threadCount;
+
+    ExecutorService executorService;
+
+    CountDownLatch latch;
+
+    private final String REQUEST_COMMENT = "문 앞에 놔주세요";
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(
+                User.of("user@email.com", "pw", "홍길동", "010-1234-5678", UserRole.USER)
+        );
+        owner = userRepository.save(
+                User.of("owner@email.com", "pw", "사장님", "010-5678-5678", UserRole.OWNER)
+        );
+
+        store = Store.builder().user(owner).name("김밥천국")
+                .category(StoreCategory.KOREAN).phoneNumber("010-1234-5678")
+                .description("맛있는 김밥").closedDays(List.of())
+                .weekdayWorkingStartTime(LocalTime.of(0, 0)).weekdayWorkingEndTime(LocalTime.of(23, 59))
+                .weekdayBreakStartTime(LocalTime.of(15, 0)).weekdayBreakEndTime(LocalTime.of(17, 0))
+                .weekendWorkingStartTime(LocalTime.of(0, 0)).weekendWorkingEndTime(LocalTime.of(23, 59))
+                .weekendBreakStartTime(LocalTime.of(15, 0)).weekendBreakEndTime(LocalTime.of(17, 0))
+                .minDeliveryPrice(10000).deliveryTip(3000)
+                .build();
+        store = storeRepository.save(store);
+
+        menu  = Menu.builder().name("짜장면").price(15000).isOption(false).store(store).status(MenuStatus.ON_SALE).build();
+        menuRepository.save(menu);
+
+        uuid = UUID.randomUUID().toString();
+
+        threadCount = 100;
+        executorService = Executors.newFixedThreadPool(threadCount);
+        latch = new CountDownLatch(threadCount);
+    }
+
+
+    @Test
+    @DisplayName("동일한 requestId로 동시에 주문 생성 시 둘 다 생성될 수 있는 문제를 테스트한다")
+    void createOrder_duplicateRequestId_concurrent() throws InterruptedException {
+        // given
+        OrderCreateRequestDto request = new OrderCreateRequestDto(
+                List.of(
+                        new OrderCreateRequestDto.MenuOrderDto(menu.getId(), 1)
+                ),
+                REQUEST_COMMENT,
+                uuid
+        );
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    orderService.createOrder(request, user.getId());
+                } catch (Exception e) {
+                    System.err.println("주문 생성 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        //then
+        long reservationCount = orderRepository.count();
+        assertThat(reservationCount).isEqualTo(1);
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
@@ -103,7 +103,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(menu2,"id",2L);
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
-        given(menuRepository.findAllByIdInAndIsDeletedFalse(anyList())).willReturn(List.of(menu1, menu2));
+        given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu1, menu2));
         given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
         given(orderRepository.save(any())).willAnswer(invocation -> {
             Order order = invocation.getArgument(0);
@@ -135,7 +135,7 @@ class OrderServiceTest {
         menu1.delete();
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
-        given(menuRepository.findAllByIdInAndIsDeletedFalse(anyList())).willReturn(List.of());
+        given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of());
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(request, 1L))
@@ -162,7 +162,7 @@ class OrderServiceTest {
         Menu menu2 = Menu.builder().name("피자").price(15000).isOption(false).store(anotherStore).build();
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
-        given(menuRepository.findAllByIdInAndIsDeletedFalse(anyList())).willReturn(List.of(menu1, menu2));
+        given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu1, menu2));
 
         assertThatThrownBy(() -> orderService.createOrder(request, 1L))
                 .isInstanceOf(BusinessException.class)
@@ -182,7 +182,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(menu,"id",1L);
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
-        given(menuRepository.findAllByIdInAndIsDeletedFalse(anyList())).willReturn(List.of(menu));
+        given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu));
         given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
 
         // when & then
@@ -209,7 +209,7 @@ class OrderServiceTest {
                 .weekdayWorkingEndTime(LocalTime.of(23, 59))
                 .build();
 
-        given(menuRepository.findAllByIdInAndIsDeletedFalse(anyList())).willReturn(List.of(menu));
+        given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu));
         given(storeRepository.findByIdOrElseThrow(1L)).willReturn(closedStore);
 
         // when & then

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
@@ -249,7 +249,7 @@ class OrderServiceTest {
         // given
         Order order = Order.builder().user(user).store(store).requestComment(REQUEST_COMMENT).build();
         ReflectionTestUtils.setField(order, "id", 1L);
-        given(orderRepository.findByIdOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdForUpdateOrElseThrow(1L)).willReturn(order);
 
         // when
         orderService.cancelOrder(1L, user.getId());
@@ -267,7 +267,7 @@ class OrderServiceTest {
         Order order = Order.builder().user(otherUser).store(store).requestComment(REQUEST_COMMENT).build();
         ReflectionTestUtils.setField(order, "id", 1L);
 
-        given(orderRepository.findByIdOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdForUpdateOrElseThrow(1L)).willReturn(order);
 
         // when & then
         assertThatThrownBy(() -> orderService.cancelOrder(1L, user.getId()))
@@ -285,7 +285,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", orderStatus);
 
-        given(orderRepository.findByIdOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdForUpdateOrElseThrow(1L)).willReturn(order);
 
         //when & then
         assertThatThrownBy(() -> orderService.cancelOrder(1L, user.getId()))
@@ -312,7 +312,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.valueOf(from));
 
-        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
 
         //when
         orderService.updateOrderStatus(1L, OrderStatus.valueOf(to), owner.getId());
@@ -337,7 +337,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.valueOf(from));
 
-        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
 
         // when & then
         assertThatThrownBy(() -> orderService.updateOrderStatus(1L, OrderStatus.valueOf(to), owner.getId()))
@@ -362,7 +362,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.valueOf(from));
 
-        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
 
         // when & then
         assertThatThrownBy(() -> orderService.updateOrderStatus(1L, OrderStatus.valueOf(to), owner.getId()))
@@ -384,7 +384,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.WAITING);
 
-        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
 
         assertThatThrownBy(() -> orderService.updateOrderStatus(1L, OrderStatus.ACCEPTED, other.getId()))
                 .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
@@ -81,6 +81,7 @@ class OrderServiceTest {
                 .weekdayWorkingStartTime(LocalTime.of(0, 0))
                 .weekdayWorkingEndTime(LocalTime.of(23, 59))
                 .build();
+        ReflectionTestUtils.setField(store,"id",1L);
     }
 
     @Test
@@ -95,8 +96,8 @@ class OrderServiceTest {
                 REQUEST_COMMENT
         );
 
-        Menu menu1 = Menu.builder().name("짜장면").price(7000).isOption(false).storeId(1L).build();
-        Menu menu2 = Menu.builder().name("짬뽕").price(8000).isOption(false).storeId(1L).build();
+        Menu menu1 = Menu.builder().name("짜장면").price(7000).isOption(false).store(store).build();
+        Menu menu2 = Menu.builder().name("짬뽕").price(8000).isOption(false).store(store).build();
 
         ReflectionTestUtils.setField(menu1,"id",1L);
         ReflectionTestUtils.setField(menu2,"id",2L);
@@ -129,7 +130,7 @@ class OrderServiceTest {
                 REQUEST_COMMENT
         );
 
-        Menu menu1 = Menu.builder().name("짜장면").price(7000).isOption(false).storeId(1L).build();
+        Menu menu1 = Menu.builder().name("짜장면").price(7000).isOption(false).store(store).build();
         ReflectionTestUtils.setField(menu1,"id",1L);
         menu1.delete();
 
@@ -153,8 +154,12 @@ class OrderServiceTest {
                 REQUEST_COMMENT
         );
 
-        Menu menu1 = Menu.builder().name("짜장면").price(7000).isOption(false).storeId(1L).build();
-        Menu menu2 = Menu.builder().name("피자").price(15000).isOption(false).storeId(2L).build();
+        Store anotherStore = Store.builder()
+                .build();
+        ReflectionTestUtils.setField(anotherStore,"id",2L);
+
+        Menu menu1 = Menu.builder().name("짜장면").price(7000).isOption(false).store(store).build();
+        Menu menu2 = Menu.builder().name("피자").price(15000).isOption(false).store(anotherStore).build();
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
         given(menuRepository.findAllByIdInAndIsDeletedFalse(anyList())).willReturn(List.of(menu1, menu2));
@@ -173,7 +178,7 @@ class OrderServiceTest {
                 REQUEST_COMMENT
         );
 
-        Menu menu = Menu.builder().name("미니샐러드").price(1000).isOption(false).storeId(1L).build();
+        Menu menu = Menu.builder().name("미니샐러드").price(1000).isOption(false).store(store).build();
         ReflectionTestUtils.setField(menu,"id",1L);
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
@@ -195,7 +200,7 @@ class OrderServiceTest {
                 REQUEST_COMMENT
         );
 
-        Menu menu = Menu.builder().name("라면").price(6000).isOption(false).storeId(1L).build();
+        Menu menu = Menu.builder().name("라면").price(6000).isOption(false).store(store).build();
         ReflectionTestUtils.setField(menu,"id",1L);
 
         Store closedStore = Store.builder()

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
@@ -104,7 +104,6 @@ class OrderServiceTest {
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
         given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu1, menu2));
-        given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
         given(orderRepository.save(any())).willAnswer(invocation -> {
             Order order = invocation.getArgument(0);
             ReflectionTestUtils.setField(order,"id",100L);
@@ -183,7 +182,6 @@ class OrderServiceTest {
 
         given(userRepository.findByIdOrElseThrow(1L)).willReturn(user);
         given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu));
-        given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(request, 1L))
@@ -200,17 +198,17 @@ class OrderServiceTest {
                 REQUEST_COMMENT
         );
 
-        Menu menu = Menu.builder().name("라면").price(6000).isOption(false).store(store).build();
-        ReflectionTestUtils.setField(menu,"id",1L);
-
         Store closedStore = Store.builder()
                 .minDeliveryPrice(12000)
                 .weekdayWorkingStartTime(LocalTime.of(23, 58))
                 .weekdayWorkingEndTime(LocalTime.of(23, 59))
                 .build();
+        ReflectionTestUtils.setField(closedStore,"id",2L);
+
+        Menu menu = Menu.builder().name("라면").price(12000).isOption(false).store(closedStore).build();
+        ReflectionTestUtils.setField(menu,"id",1L);
 
         given(menuRepository.findAllByIdInAndNotDeleted(anyList())).willReturn(List.of(menu));
-        given(storeRepository.findByIdOrElseThrow(1L)).willReturn(closedStore);
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(request, 1L))

--- a/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/order/service/OrderServiceTest.java
@@ -249,7 +249,7 @@ class OrderServiceTest {
         // given
         Order order = Order.builder().user(user).store(store).requestComment(REQUEST_COMMENT).build();
         ReflectionTestUtils.setField(order, "id", 1L);
-        given(orderRepository.findByIdForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdOrElseThrow(1L)).willReturn(order);
 
         // when
         orderService.cancelOrder(1L, user.getId());
@@ -267,7 +267,7 @@ class OrderServiceTest {
         Order order = Order.builder().user(otherUser).store(store).requestComment(REQUEST_COMMENT).build();
         ReflectionTestUtils.setField(order, "id", 1L);
 
-        given(orderRepository.findByIdForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdOrElseThrow(1L)).willReturn(order);
 
         // when & then
         assertThatThrownBy(() -> orderService.cancelOrder(1L, user.getId()))
@@ -285,7 +285,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", orderStatus);
 
-        given(orderRepository.findByIdForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdOrElseThrow(1L)).willReturn(order);
 
         //when & then
         assertThatThrownBy(() -> orderService.cancelOrder(1L, user.getId()))
@@ -312,7 +312,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.valueOf(from));
 
-        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
 
         //when
         orderService.updateOrderStatus(1L, OrderStatus.valueOf(to), owner.getId());
@@ -337,7 +337,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.valueOf(from));
 
-        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
 
         // when & then
         assertThatThrownBy(() -> orderService.updateOrderStatus(1L, OrderStatus.valueOf(to), owner.getId()))
@@ -362,7 +362,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.valueOf(from));
 
-        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
 
         // when & then
         assertThatThrownBy(() -> orderService.updateOrderStatus(1L, OrderStatus.valueOf(to), owner.getId()))
@@ -384,7 +384,7 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(order, "id", 1L);
         ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.WAITING);
 
-        given(orderRepository.findByIdWithStoreForUpdateOrElseThrow(1L)).willReturn(order);
+        given(orderRepository.findByIdWithStoreOrElseThrow(1L)).willReturn(order);
 
         assertThatThrownBy(() -> orderService.updateOrderStatus(1L, OrderStatus.ACCEPTED, other.getId()))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: [태그] #이슈번호 : 간단한 설명
  예시: [Feat] #12 : 로그인 API 연동
-->


## 🔎 작업 내용

주문 관련 도메인에서 발생할 수 있는 동시성 상황에 대해 해결하였습니다. (동시성 문제 정리 : 이슈 #71 )
### 주문 요청 API 동시성 테스트 코드
스레드 100개로 동일한 requestId를 가지고 주문 요청을 하도록 테스트 코드를 짰습니다. 

### 주문 요청 API 동시성 해결
idempotency key 사용하여 동시성 제어를 했습니다. 요청할 때 고유한 requestId를 바디로 같이 보내면, 서버는 이 requestId 저장하고 있다가 이미 처리된 요청은 무시하였습니다. 

### 주문 취소 + 상태 변경 API 동시성 테스트 코드
스레드 50개는 주문 취소, 나머지 50개는 주문 상태를 ACCEPTED로 변경하도록 테스트 로직을 짜고, 최종적으로 1개만 성공하는지 확인하는 테스트 코드를 구현하였습니다.
동시성 코드 구현 전에는 테스트 코드가 실패하였습니다.

### 주문 취소 + 상태 변경 API 동시성 해결 
이를 해결하기 위해 먼저 SELECT ... FOR UPDATE 즉, 비관적 락을 사용하여 조회한 row에 X lock(배타적 락)을 걸었습니다. 이를 통해 다른 트랜잭션에서는 해당 row에 대해 s lock과 x lock을 모두 소유할 수 없으므로, 동시성을 해결할 수 있습니다.

두 번째로 낙관적 락을 적용하였습니다. 주문 엔티티에 version 속성을 추가하여, 커밋 시 version 갱신 여부를 확인하여 상태 변경을 하였고, 이를 통해 동시성을 해결할 수 있었습니다.

주문 상태변경 기능은 충돌 가능성이 크지 않으므로, 비관적 락이 아닌 낙관적 락을 사용하였습니다.

## ➕ 트러블 슈팅

### 주문 요청 동시성 구현에 추가적인 락 적용이 필요없는 이유
SELECT는 MVCC가 적용되어 다른 트랜잭션의 삽입을 보지 못합니다. (Phantom Read) 따라서 처음에는 주문 생성에 대한 동시성 테스트 코드에 대해 실패를 예상하였지만 테스트 코드가 성공하였습니다. 

이는 유니크 인덱스(requestId)가 걸린 row를 insert 할 때에는 커밋 여부와 상관 없이 Unique 인덱스 레벨에서 강제 체크하기 때문이었습니다. 따라서, 추가적인 락 적용이 없이도 동시성이 해결되었습니다.
=> 실제로, requestId 필드에 unique 속성을 제거하였더니, 동시성 테스트에서 실패했습니다.

## 🔧 해결해야할 문제

없습니다.

closed #71 