### PR TITLE
[Feat] #84 : 인수 테스트 작성 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,14 @@ dependencies {
 
     // OAuth2 Client
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // test container
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql:1.20.6'          // MySQL 컨테이너 사용
+
+    // RestAssured
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/menu/dto/response/AllMenuResponseDto.java
@@ -5,12 +5,13 @@ import com.ddukbbegi.api.menu.enums.Category;
 import com.ddukbbegi.api.menu.enums.MenuStatus;
 
 public record AllMenuResponseDto(
+	Long menuId,
 	String name,
 	int price,
 	Category category,
 	MenuStatus status
 ) {
 	public static AllMenuResponseDto toDto(Menu menu) {
-		return new AllMenuResponseDto(menu.getName(), menu.getPrice(), menu.getCategory(), menu.getStatus());
+		return new AllMenuResponseDto(menu.getId(), menu.getName(), menu.getPrice(), menu.getCategory(), menu.getStatus());
 	}
 }

--- a/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
+++ b/src/main/java/com/ddukbbegi/api/order/service/OrderService.java
@@ -15,6 +15,7 @@ import com.ddukbbegi.api.order.repository.OrderMenuRepository;
 import com.ddukbbegi.api.order.repository.OrderRepository;
 import com.ddukbbegi.api.review.repository.ReviewRepository;
 import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
 import com.ddukbbegi.api.user.entity.User;
 import com.ddukbbegi.api.user.repository.UserRepository;
 import com.ddukbbegi.common.component.ResultCode;
@@ -66,10 +67,7 @@ public class OrderService {
         Store store = menus.get(0).getStore();
 
         checkIsAllSameStore(menus, store.getId());
-
-        LocalTime now = now();
-        checkStoreIsWorking(now,store);
-
+        checkStoreIsWorking(store);
         checkIsTotalPriceOverMinDeliveryPrice(menus,request,store.getMinDeliveryPrice());
 
         Order order = Order.builder()
@@ -131,8 +129,8 @@ public class OrderService {
         return totalPrice;
     }
 
-    private void checkStoreIsWorking(LocalTime now,Store store) {
-        if (now.isBefore(store.getWeekdayWorkingStartTime()) || now.isAfter(store.getWeekdayWorkingEndTime())) {
+    private void checkStoreIsWorking(Store store) {
+        if (!store.getStatus().equals(StoreStatus.OPEN)) {
             throw new BusinessException(ResultCode.STORE_NOT_WORKING);
         }
     }

--- a/src/main/java/com/ddukbbegi/api/review/service/ReviewService.java
+++ b/src/main/java/com/ddukbbegi/api/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.ddukbbegi.api.review.service;
 
 
 import com.ddukbbegi.api.order.entity.Order;
+import com.ddukbbegi.api.order.enums.OrderStatus;
 import com.ddukbbegi.api.order.repository.OrderRepository;
 import com.ddukbbegi.api.review.dto.*;
 import com.ddukbbegi.api.review.entity.Review;
@@ -33,8 +34,13 @@ public class ReviewService {
 
     public ReviewResponseDto saveReview(Long userId, ReviewRequestDto requestDto){
         Order findOrder = orderRepository.findByIdOrElseThrow(requestDto.orderId());
+        if (findOrder.getOrderStatus() != OrderStatus.DELIVERED) {
+            throw new BusinessException(ResultCode.ORDER_NOT_DELIVERED);
+        }
+
         User findUser = userRepository.findByIdOrElseThrow(userId);
         Review review = Review.from(findUser, findOrder,requestDto);
+
         Review savedReview = reviewRepository.save(review);
         Long likeCount = reviewLikeRepository.countLikesByReviewId(savedReview.getId());
         return ReviewResponseDto.from(savedReview, likeCount);

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/RequestStoreBasicInfo.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/RequestStoreBasicInfo.java
@@ -23,7 +23,7 @@ public record RequestStoreBasicInfo(
         String description
 ) {
 
-    public StoreCategory getCategory() {
+    public StoreCategory toCategory() {
         return StoreCategory.fromString(this.category);
     }
 

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/RequestStoreOperationInfo.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/RequestStoreOperationInfo.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public record RequestStoreOperationInfo(
         @Pattern(
-                regexp = "^(MON|TUE|WED|THU|FRI|SAT|SUN)(,(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
+                regexp = "^$|^(MON|TUE|WED|THU|FRI|SAT|SUN)(\\s*,\\s*(MON|TUE|WED|THU|FRI|SAT|SUN)){0,6}$",
                 message = "정기 휴무일 형식이 올바르지 않습니다. 예: SUN,MON"
         ) String closedDays,
         @Pattern(regexp = "^\\d{2}:\\d{2}-\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm-HH:mm 이어야 합니다.") String weekdayWorkingTime,
@@ -25,10 +25,18 @@ public record RequestStoreOperationInfo(
      * 내부 파싱 로직을 통해 Entity 빌더에서 사용하기 좋은 자료형으로 변환
      */
     public ParsedOperationInfo toParsedData() {
+        List<DayOfWeek> closedDayList;
+
+        if (closedDays == null || closedDays.isBlank()) {
+            closedDayList = List.of();
+        } else {
+            closedDayList = Arrays.stream(closedDays.split(","))
+                    .map(DayOfWeek::valueOf)
+                    .toList();
+        }
+
         return new ParsedOperationInfo(
-                Arrays.stream(closedDays.split(","))
-                        .map(DayOfWeek::valueOf)
-                        .toList(),
+                closedDayList,
                 TimeRangeParser.parse(weekdayWorkingTime),
                 TimeRangeParser.parse(weekdayBreakTime),
                 TimeRangeParser.parse(weekendWorkingTime),

--- a/src/main/java/com/ddukbbegi/api/store/dto/request/StoreRegisterRequestDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/request/StoreRegisterRequestDto.java
@@ -25,7 +25,7 @@ public record StoreRegisterRequestDto(
         return Store.builder()
                 .user(user)
                 .name(basicInfoDto.name())
-                .category(basicInfoDto.getCategory())
+                .category(basicInfoDto.toCategory())
                 .phoneNumber(basicInfoDto.phoneNumber())
                 .description(basicInfoDto.description())
 

--- a/src/main/java/com/ddukbbegi/api/store/dto/response/StorePageItemResponseDto.java
+++ b/src/main/java/com/ddukbbegi/api/store/dto/response/StorePageItemResponseDto.java
@@ -4,6 +4,7 @@ import com.ddukbbegi.api.store.entity.Store;
 import com.ddukbbegi.api.store.enums.StoreStatus;
 
 public record StorePageItemResponseDto(
+        Long storeId,
         String name,
         String description,
         String storeCategory,
@@ -15,6 +16,7 @@ public record StorePageItemResponseDto(
     public static StorePageItemResponseDto fromEntity(Store store) {
 
         return new StorePageItemResponseDto(
+                store.getId(),
                 store.getName(),
                 store.getDescription(),
                 store.getCategory().getDesc(),

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -93,7 +93,7 @@ public class StoreService {
         RequestStoreBasicInfo basicInfoDto = dto.basicInfoDto();
         store.updateBasicInfo(
                 basicInfoDto.name(),
-                basicInfoDto.getCategory(),
+                basicInfoDto.toCategory(),
                 basicInfoDto.phoneNumber(),
                 basicInfoDto.description()
         );

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -16,12 +16,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class StoreService {
+
+    private final StoreStatusResolveService storeStatusResolveService;
 
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
@@ -141,9 +144,8 @@ public class StoreService {
         checkStoreOwnerPermission(store, userId);
 
         store.updateTemporarilyClosed(dto.status());
-        if (dto.status()) {
-            store.updateStatus(StoreStatus.TEMPORARILY_CLOSED);
-        }
+        StoreStatus storeStatus = storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now());
+        store.updateStatus(storeStatus);
     }
 
     @Transactional
@@ -158,9 +160,8 @@ public class StoreService {
         }
 
         store.updatePermanentlyClosed(dto.status());
-        if (dto.status()) {
-            store.updateStatus(StoreStatus.PERMANENTLY_CLOSED);
-        }
+        StoreStatus storeStatus = storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now());
+        store.updateStatus(storeStatus);
     }
 
     private void checkStoreOwnerPermission(Store store, Long userId) {

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -4,6 +4,7 @@ import com.ddukbbegi.api.common.dto.PageResponseDto;
 import com.ddukbbegi.api.store.dto.request.*;
 import com.ddukbbegi.api.store.dto.response.*;
 import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
 import com.ddukbbegi.api.store.repository.StoreRepository;
 import com.ddukbbegi.api.user.entity.User;
 import com.ddukbbegi.api.user.repository.UserRepository;
@@ -140,6 +141,9 @@ public class StoreService {
         checkStoreOwnerPermission(store, userId);
 
         store.updateTemporarilyClosed(dto.status());
+        if (dto.status()) {
+            store.updateStatus(StoreStatus.TEMPORARILY_CLOSED);
+        }
     }
 
     @Transactional
@@ -154,6 +158,9 @@ public class StoreService {
         }
 
         store.updatePermanentlyClosed(dto.status());
+        if (dto.status()) {
+            store.updateStatus(StoreStatus.PERMANENTLY_CLOSED);
+        }
     }
 
     private void checkStoreOwnerPermission(Store store, Long userId) {

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreService.java
@@ -39,6 +39,7 @@ public class StoreService {
         User user = userRepository.findByIdOrElseThrow(userId);
 
         Store store = dto.toEntity(user);
+        store.updateStatus(storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now()));
         Store savedStore = storeRepository.save(store);
 
         return StoreIdResponseDto.of(savedStore.getId());
@@ -144,8 +145,7 @@ public class StoreService {
         checkStoreOwnerPermission(store, userId);
 
         store.updateTemporarilyClosed(dto.status());
-        StoreStatus storeStatus = storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now());
-        store.updateStatus(storeStatus);
+        store.updateStatus(storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now()));
     }
 
     @Transactional
@@ -160,8 +160,7 @@ public class StoreService {
         }
 
         store.updatePermanentlyClosed(dto.status());
-        StoreStatus storeStatus = storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now());
-        store.updateStatus(storeStatus);
+        store.updateStatus(storeStatusResolveService.resolveStoreStatus(store, LocalDateTime.now()));
     }
 
     private void checkStoreOwnerPermission(Store store, Long userId) {

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreStatusResolveService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreStatusResolveService.java
@@ -31,6 +31,10 @@ public class StoreStatusResolveService {
         LocalTime breakStart = isWeekend ? store.getWeekendBreakStartTime() : store.getWeekdayBreakStartTime();
         LocalTime breakEnd = isWeekend ? store.getWeekendBreakEndTime() : store.getWeekdayBreakEndTime();
 
+        // 24시간 영업 표시용
+        if (openTime.equals(closeTime)) {
+            return StoreStatus.OPEN;
+        }
 
         if (isWithin(time, breakStart, breakEnd)) {
             return StoreStatus.BREAK;

--- a/src/main/java/com/ddukbbegi/api/store/service/StoreStatusResolveService.java
+++ b/src/main/java/com/ddukbbegi/api/store/service/StoreStatusResolveService.java
@@ -8,6 +8,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+// static 클래스보다는 Bean으로 관리하는게 테스트 시 편리함
 @Service
 public class StoreStatusResolveService {
 

--- a/src/main/java/com/ddukbbegi/common/component/ResultCode.java
+++ b/src/main/java/com/ddukbbegi/common/component/ResultCode.java
@@ -47,7 +47,10 @@ public enum ResultCode {
     ORDER_ALREADY_TERMINATED(HttpStatus.BAD_REQUEST,"E208" ,"이미 종료된 주문입니다." ),
     STORE_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "E209", "본인 가게의 주문이 아닙니다."),
     ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST,"E210", "존재하지 않는 주문입니다."),
-    DUPLICATE_REQUEST_ID(HttpStatus.BAD_REQUEST, "E211", "이미 요청된 주문입니다.");
+    DUPLICATE_REQUEST_ID(HttpStatus.BAD_REQUEST, "E211", "이미 요청된 주문입니다."),
+
+    /* 리뷰 도메인 */
+    ORDER_NOT_DELIVERED(HttpStatus.BAD_REQUEST, "E401", "아직 배달 완료되지 않은 주문에는 리뷰를 작성할 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/test/java/com/ddukbbegi/DdukbbegiApplicationTests.java
+++ b/src/test/java/com/ddukbbegi/DdukbbegiApplicationTests.java
@@ -2,8 +2,10 @@ package com.ddukbbegi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DdukbbegiApplicationTests {
 
 	@Test

--- a/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
@@ -1,8 +1,6 @@
 package com.ddukbbegi.acceptance;
 
 import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
-import com.ddukbbegi.api.order.enums.OrderStatus;
-import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
 import com.ddukbbegi.api.user.enums.UserRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +10,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("인수 테스트 - Admin")

--- a/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
@@ -1,27 +1,78 @@
 package com.ddukbbegi.acceptance;
 
 import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
+import com.ddukbbegi.api.order.enums.OrderStatus;
+import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
 import com.ddukbbegi.api.user.enums.UserRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("인수 테스트 - Admin")
 public class AdminAcceptanceTest extends AcceptanceTestSupport {
 
-    private final String email = "admin@test.com";
-
-    @DisplayName("어드민 계정 생성 및 일간/월간 주문수 조회")
+    @DisplayName("1. (어드민) 일간/월간 주문수를 조회한다.")
     @Test
     void 어드민_일간_월간_주문수_조회() {
         // given
-        회원가입하고_로그인(email, UserRole.ADMIN);
+        회원가입하고_로그인("owner51@test.com", UserRole.OWNER);
+        Long storeId = 사장_24시운영_가게등록();
+        Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
+
+        회원가입하고_로그인("user51@test.com", UserRole.USER);
+        Long orderId1 = 유저_주문요청(List.of(menuId1, menuId2));
+        Long orderId2 = 유저_주문요청(List.of(menuId1, menuId2));
+
+        사장_주문수락(orderId1);
+        사장_주문수락(orderId2);
+
+        회원가입하고_로그인("admin@test.com", UserRole.ADMIN);
 
         // when
+        Long 일간주문수 = 어드민_일간주문수_조회();
+        Long 월간주문수 = 어드민_월간주문수_조회();
 
         // then
-        assertThat(adminAccessToken).isNotNull();
+        assertThat(일간주문수).isEqualTo(2);
+        assertThat(월간주문수).isEqualTo(2);
+    }
+
+    private Long 어드민_일간주문수_조회() {
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return given()
+                .header("Authorization", adminAccessToken)
+                .queryParam("date", today.format(formatter))
+            .when()
+                .get("/api/admin/orderCount/date")
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getLong("data.totalOrder");
+    }
+
+    private Long 어드민_월간주문수_조회() {
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        return given()
+                .header("Authorization", adminAccessToken)
+                .queryParam("month", today.format(formatter))
+            .when()
+                .get("/api/admin/orderCount/month")
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getLong("data.totalOrder");
     }
 
 }

--- a/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
@@ -1,0 +1,27 @@
+package com.ddukbbegi.acceptance;
+
+import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
+import com.ddukbbegi.api.user.enums.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Admin 인수 테스트")
+public class AdminAcceptanceTest extends AcceptanceTestSupport {
+
+    private final String email = "admin@test.com";
+
+    @DisplayName("어드민 계정 생성 및 일간/월간 주문수 조회")
+    @Test
+    void 어드민_일간_월간_주문수_조회() {
+        // given
+        회원가입하고_로그인(email, UserRole.ADMIN);
+
+        // when
+
+        // then
+        assertThat(adminAccessToken).isNotNull();
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/AdminAcceptanceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Admin 인수 테스트")
+@DisplayName("인수 테스트 - Admin")
 public class AdminAcceptanceTest extends AcceptanceTestSupport {
 
     private final String email = "admin@test.com";

--- a/src/test/java/com/ddukbbegi/acceptance/MenuAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/MenuAcceptanceTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Menu 인수 테스트")
+@DisplayName("인수 테스트 - Menu")
 public class MenuAcceptanceTest extends AcceptanceTestSupport {
 
     @DisplayName("1. (사장) 메뉴를 등록하고 수정한다.")

--- a/src/test/java/com/ddukbbegi/acceptance/MenuAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/MenuAcceptanceTest.java
@@ -1,0 +1,124 @@
+package com.ddukbbegi.acceptance;
+
+import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
+import com.ddukbbegi.api.menu.dto.request.UpdatingMenuRequestDto;
+import com.ddukbbegi.api.menu.dto.response.AllMenuResponseDto;
+import com.ddukbbegi.api.menu.dto.response.DetailMenuResponseDto;
+import com.ddukbbegi.api.menu.entity.Menu;
+import com.ddukbbegi.api.menu.enums.Category;
+import com.ddukbbegi.api.user.enums.UserRole;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Menu 인수 테스트")
+public class MenuAcceptanceTest extends AcceptanceTestSupport {
+
+    @DisplayName("1. (사장) 메뉴를 등록하고 수정한다.")
+    @Test
+    void menu() {
+        // given
+        String accessToken = 회원가입하고_로그인("owner21@test.com", UserRole.OWNER);
+        Long storeId = 사장_가게등록(accessToken);
+        Long menuId1 = 사장_메뉴등록(accessToken, storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(accessToken, storeId, "오이김밥");
+        List<AllMenuResponseDto> 메뉴목록 = 사장_메뉴목록조회(accessToken, storeId);
+
+        // when
+        사장_메뉴수정(accessToken, storeId, 메뉴목록.get(0).menuId(), "치즈김밥");
+
+        // then
+        List<Menu> storeList = menuRepository.findAllByStoreId(storeId);    // 실제 DB 검증
+        assertThat(storeList.size()).isEqualTo(2);
+        assertThat(storeList.get(0).getName()).isEqualTo("치즈김밥");
+    }
+
+    @DisplayName("2. (유저) 목록 목록을 조회하고 그 중 하나를 골라 상세 조회한다.")
+    @Test
+    void getMenusAndMenuDetail() {
+        // given
+        String accessToken = 회원가입하고_로그인("owner22@test.com", UserRole.OWNER);
+        Long storeId = 사장_가게등록(accessToken);
+        Long menuId1 = 사장_메뉴등록(accessToken, storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(accessToken, storeId, "오이김밥");
+        Long menuId3 = 사장_메뉴등록(accessToken, storeId, "치즈김밥");
+
+        사장_메뉴삭제(accessToken, storeId, menuId2);
+        List<AllMenuResponseDto> menuList = 유저_메뉴목록조회(accessToken, storeId);
+
+        // when
+        DetailMenuResponseDto 메뉴상세 = 유저_메뉴상세조회(accessToken, storeId, menuList.get(0).menuId());
+
+        // then
+        assertThat(menuList.size()).isEqualTo(2);   // 삭제된 메뉴는 조회되지 않기 때문에 데이터는 2개
+        assertThat(메뉴상세.name()).isEqualTo("참치김밥");
+    }
+
+    private List<AllMenuResponseDto> 사장_메뉴목록조회(String accessToken, Long storeId) {
+        return given()
+                .header("Authorization", accessToken)
+            .when()
+                .get("/api/owner/stores/{storeId}/menus", storeId)
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getList("data", AllMenuResponseDto.class);
+    }
+
+    private List<AllMenuResponseDto> 유저_메뉴목록조회(String accessToken, Long storeId) {
+        return given()
+                .header("Authorization", accessToken)
+            .when()
+                .get("/api/stores/{storeId}/menus", storeId)
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getList("data", AllMenuResponseDto.class);
+    }
+    
+    private DetailMenuResponseDto 유저_메뉴상세조회(String accessToken, Long storeId, Long menuId) {
+        return given()
+                .header("Authorization", accessToken)
+            .when()
+                .get("/api/stores/{storeId}/menus/{menuId}", storeId, menuId)
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getObject("data", DetailMenuResponseDto.class);
+    }
+
+    private void 사장_메뉴수정(String accessToken, Long storeId, Long menuId, String menuName) {
+        given()
+                .header("Authorization", accessToken)
+                .contentType(ContentType.JSON)
+                .body(new UpdatingMenuRequestDto(menuName,
+                        2000,
+                        "UpdatedDesc",
+                        Category.MAIN_MENU))
+            .when()
+                .put("/api/owner/stores/{storeId}/menus/{menuId}", storeId, menuId)
+            .then()
+                .statusCode(200);
+    }
+
+    private void 사장_메뉴삭제(String accessToken, Long storeId, Long menuId) {
+        given()
+                .header("Authorization", accessToken)
+                .contentType(ContentType.JSON)
+                .body(Map.of("status", "DELETED"))
+            .when()
+                .patch("/api/owner/stores/{storeId}/menus/{menuId}", storeId, menuId)
+            .then()
+                .statusCode(200);
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/acceptance/OrderAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/OrderAcceptanceTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("Order 인수 테스트")
+@DisplayName("인수 테스트 - Order")
 public class OrderAcceptanceTest extends AcceptanceTestSupport {
 
     @DisplayName("1. (사장) 메뉴 등록 후 주문 요청이 들어오면 내용을 확인하고 수락한다.")

--- a/src/test/java/com/ddukbbegi/acceptance/OrderAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/OrderAcceptanceTest.java
@@ -1,0 +1,106 @@
+package com.ddukbbegi.acceptance;
+
+import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
+import com.ddukbbegi.api.order.dto.response.OrderHistoryOwnerResponseDto;
+import com.ddukbbegi.api.order.entity.Order;
+import com.ddukbbegi.api.order.enums.OrderStatus;
+import com.ddukbbegi.api.user.enums.UserRole;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Order 인수 테스트")
+public class OrderAcceptanceTest extends AcceptanceTestSupport {
+
+    @DisplayName("1. (사장) 메뉴 등록 후 주문 요청이 들어오면 내용을 확인하고 수락한다.")
+    @Test
+    void givenOrdersThenAcceptThem() {
+        // given
+        회원가입하고_로그인("owner31@test.com", UserRole.OWNER);
+        Long storeId = 사장_24시운영_가게등록();
+        Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
+
+        회원가입하고_로그인("user31@test.com", UserRole.USER);
+        Long orderId = 유저_주문요청(List.of(menuId1, menuId2));
+
+        List<OrderHistoryOwnerResponseDto> 사장_주문내역 = 사장_주문내역조회(storeId);
+
+        // when
+        사장_주문수락(orderId);
+
+        // then
+        assertThat(사장_주문내역.size()).isEqualTo(1);
+
+        Page<Order> orders = orderRepository.findAllByStoreId(storeId, PageRequest.of(0, 10));
+        Order order = orders.getContent().get(0);
+        assertThat(orders.getContent().size()).isEqualTo(1);
+        assertThat(order.getId()).isEqualTo(orderId);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.ACCEPTED);
+    }
+
+    @DisplayName("2. (유저) 주문을 요청했다가 취소한다.")
+    @Test
+    void createOrderAndCancelIt() {
+        // given
+        회원가입하고_로그인("owner32@test.com", UserRole.OWNER);
+        Long storeId = 사장_24시운영_가게등록();
+        Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
+
+        회원가입하고_로그인("user32@test.com", UserRole.USER);
+        Long orderId = 유저_주문요청(List.of(menuId1, menuId2));
+
+        // when
+        유저_주문취소(orderId);
+
+        // then
+        Page<Order> orders = orderRepository.findAllByStoreId(storeId, PageRequest.of(0, 10));
+        Order order = orders.getContent().get(0);
+        assertThat(orders.getContent().size()).isEqualTo(1);
+        assertThat(order.getId()).isEqualTo(orderId);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CANCELED);
+    }
+
+    private List<OrderHistoryOwnerResponseDto> 사장_주문내역조회(Long storeId) {
+        return given()
+                .header("Authorization", ownerAccessToken)
+            .when()
+                .get("/api/owner/stores/{storeId}/orders", storeId)
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getList("data.data", OrderHistoryOwnerResponseDto.class);
+    }
+
+    private void 사장_주문수락(Long orderId) {
+        given()
+                .header("Authorization", ownerAccessToken)
+                .contentType(ContentType.JSON)
+                .queryParam("status", "ACCEPTED")
+            .when()
+                .patch("/api/owner/orders/{orderId}", orderId)
+            .then()
+                .statusCode(200);
+    }
+
+    private void 유저_주문취소(Long orderId) {
+        given()
+                .header("Authorization", userAccessToken)
+                .contentType(ContentType.JSON)
+                .queryParam("status", "ACCEPTED")
+            .when()
+                .patch("/api/orders/{orderId}/cancel", orderId)
+            .then()
+                .statusCode(200);
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/acceptance/OrderAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/OrderAcceptanceTest.java
@@ -81,17 +81,6 @@ public class OrderAcceptanceTest extends AcceptanceTestSupport {
                 .getList("data.data", OrderHistoryOwnerResponseDto.class);
     }
 
-    private void 사장_주문수락(Long orderId) {
-        given()
-                .header("Authorization", ownerAccessToken)
-                .contentType(ContentType.JSON)
-                .queryParam("status", "ACCEPTED")
-            .when()
-                .patch("/api/owner/orders/{orderId}", orderId)
-            .then()
-                .statusCode(200);
-    }
-
     private void 유저_주문취소(Long orderId) {
         given()
                 .header("Authorization", userAccessToken)

--- a/src/test/java/com/ddukbbegi/acceptance/ReviewAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/ReviewAcceptanceTest.java
@@ -23,12 +23,12 @@ public class ReviewAcceptanceTest extends AcceptanceTestSupport {
     @Test
     void doOrderThenWriteReview() {
         // given
-        회원가입하고_로그인("owner31@test.com", UserRole.OWNER);
+        회원가입하고_로그인("owner41@test.com", UserRole.OWNER);
         Long storeId = 사장_24시운영_가게등록();
         Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
         Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
 
-        회원가입하고_로그인("user31@test.com", UserRole.USER);
+        회원가입하고_로그인("user41@test.com", UserRole.USER);
         Long orderId = 유저_주문요청(List.of(menuId1, menuId2));
 
         사장_주문수락(orderId);
@@ -51,12 +51,12 @@ public class ReviewAcceptanceTest extends AcceptanceTestSupport {
     @Test
     void replyReview() {
         // given
-        회원가입하고_로그인("owner32@test.com", UserRole.OWNER);
+        회원가입하고_로그인("owner42@test.com", UserRole.OWNER);
         Long storeId = 사장_24시운영_가게등록();
         Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
         Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
 
-        회원가입하고_로그인("user32@test.com", UserRole.USER);
+        회원가입하고_로그인("user42@test.com", UserRole.USER);
         Long orderId = 유저_주문요청(List.of(menuId1, menuId2));
 
         사장_주문수락(orderId);

--- a/src/test/java/com/ddukbbegi/acceptance/ReviewAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/ReviewAcceptanceTest.java
@@ -1,0 +1,4 @@
+package com.ddukbbegi.acceptance;
+
+public class ReviewAcceptanceTest {
+}

--- a/src/test/java/com/ddukbbegi/acceptance/ReviewAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/ReviewAcceptanceTest.java
@@ -1,4 +1,113 @@
 package com.ddukbbegi.acceptance;
 
-public class ReviewAcceptanceTest {
+import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
+import com.ddukbbegi.api.order.entity.Order;
+import com.ddukbbegi.api.order.enums.OrderStatus;
+import com.ddukbbegi.api.review.dto.ReviewOwnerRequestDto;
+import com.ddukbbegi.api.review.entity.Review;
+import com.ddukbbegi.api.user.enums.UserRole;
+import com.ddukbbegi.support.fixture.ReviewFixture;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("인수 테스트 - Review")
+public class ReviewAcceptanceTest extends AcceptanceTestSupport {
+
+    @DisplayName("1. (유저) 주문 후 리뷰를 등록한다.")
+    @Test
+    void doOrderThenWriteReview() {
+        // given
+        회원가입하고_로그인("owner31@test.com", UserRole.OWNER);
+        Long storeId = 사장_24시운영_가게등록();
+        Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
+
+        회원가입하고_로그인("user31@test.com", UserRole.USER);
+        Long orderId = 유저_주문요청(List.of(menuId1, menuId2));
+
+        사장_주문수락(orderId);
+        사장_주문상태변경(orderId, OrderStatus.COOKING);        // 요리 중
+        사장_주문상태변경(orderId, OrderStatus.DELIVERING);     // 배달 중
+        사장_주문상태변경(orderId, OrderStatus.DELIVERED);      // 배달 완료
+
+        // when
+        Long reviewId = 유저_리뷰작성(orderId);
+
+        // then
+        Order order = orderRepository.findByIdOrElseThrow(orderId);
+        Review review = reviewRepository.findByIdOrElseThrow(reviewId);
+
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.DELIVERED);
+        assertThat(review.getContents()).isEqualTo("잘 먹었습니다.");
+    }
+
+    @DisplayName("2. (사장) 자신의 가게에 달린 리뷰에 답글을 작성한다.")
+    @Test
+    void replyReview() {
+        // given
+        회원가입하고_로그인("owner32@test.com", UserRole.OWNER);
+        Long storeId = 사장_24시운영_가게등록();
+        Long menuId1 = 사장_메뉴등록(storeId, "참치김밥");
+        Long menuId2 = 사장_메뉴등록(storeId, "치즈김밥");
+
+        회원가입하고_로그인("user32@test.com", UserRole.USER);
+        Long orderId = 유저_주문요청(List.of(menuId1, menuId2));
+
+        사장_주문수락(orderId);
+        사장_주문상태변경(orderId, OrderStatus.COOKING);        // 요리 중
+        사장_주문상태변경(orderId, OrderStatus.DELIVERING);     // 배달 중
+        사장_주문상태변경(orderId, OrderStatus.DELIVERED);      // 배달 완료
+
+        Long reviewId = 유저_리뷰작성(orderId);
+
+        // when
+        사장_리뷰답글(reviewId);
+
+        // then
+        Review review = reviewRepository.findByIdOrElseThrow(reviewId);
+        assertThat(review.getReply()).isEqualTo("감사합니다!");
+    }
+
+    private void 사장_주문상태변경(Long orderId, OrderStatus orderStatus) {
+        given()
+                .header("Authorization", ownerAccessToken)
+                .contentType(ContentType.JSON)
+                .queryParam("status", orderStatus.name())
+            .when()
+                .patch("/api/owner/orders/{orderId}", orderId)
+            .then()
+                .statusCode(200);
+    }
+
+    private Long 유저_리뷰작성(Long orderId) {
+        return given()
+                .header("Authorization", userAccessToken)
+                .contentType(ContentType.JSON)
+                .body(ReviewFixture.createReviewRequestDto(orderId, "잘 먹었습니다."))
+            .when()
+                .post("/api/reviews")
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getLong("data.reviewId");
+    }
+
+    private void 사장_리뷰답글(Long reviewId) {
+        given()
+                .header("Authorization", ownerAccessToken)
+                .contentType(ContentType.JSON)
+                .body(new ReviewOwnerRequestDto("감사합니다!"))
+            .when()
+                .post("/api/owners/reviews/{reviewId}/reply", reviewId)
+            .then()
+                .statusCode(200);
+    }
+    
 }

--- a/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
@@ -1,0 +1,105 @@
+package com.ddukbbegi.acceptance;
+
+import com.ddukbbegi.api.auth.dto.request.LoginRequestDto;
+import com.ddukbbegi.api.auth.dto.request.SignupRequestDto;
+import com.ddukbbegi.api.store.repository.StoreRepository;
+import com.ddukbbegi.support.config.TestContainersConfig;
+import com.ddukbbegi.support.fixture.StoreFixture;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("testcontainers")
+@Transactional
+public class StoreAcceptanceTest extends TestContainersConfig {
+    
+    @LocalServerPort
+    int port;
+
+    private final String email = "test@test.com";
+    private final String password = "Pwdpwdpwd1!";
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void contextLoads() {
+        // 테스트 환경 정상 동작 하는지 확인하기 위해 사용
+    }
+
+    @DisplayName("1. 사장이 가게 등록 후 조회")
+    @Test
+    void registerStoreAndGet() {
+        // given
+        회원가입_사장();
+        String accessToken = 로그인_및_액세스_토큰_발급();
+
+        // when
+        Long storeId = 사장_가게_등록(accessToken);
+
+        // then
+        사장가게상세_조회_검증(accessToken, storeId, "맛있는김밥");
+    }
+
+    private void 회원가입_사장() {
+        given()
+                .contentType(ContentType.JSON)
+                .body(new SignupRequestDto(email, password, "test", "010-1234-5678", "OWNER"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(200);
+    }
+
+    private String 로그인_및_액세스_토큰_발급() {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(new LoginRequestDto(email, password))
+                .when()
+                .post("/api/auth/login")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.accessToken");
+    }
+
+    private Long 사장_가게_등록(String accessToken) {
+        return given()
+                .header("Authorization", accessToken)
+                .contentType(ContentType.JSON)
+                .body(StoreFixture.createStoreRegisterRequestDto())
+                .when()
+                .post("/api/owner/stores")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getLong("data.storeId");
+    }
+    
+    private void 사장가게상세_조회_검증(String accessToken, Long storeId, String expectedName) {
+        given()
+                .header("Authorization", accessToken)
+                .get("/api/owner/stores/{storeId}", storeId)
+                .then()
+                .statusCode(200)
+                .body("data.basicInfo.name", equalTo(expectedName));
+    }
+
+    private void 사장_가게_정보_수정(String accessToken, Long storeId) {
+
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
@@ -1,105 +1,144 @@
 package com.ddukbbegi.acceptance;
 
-import com.ddukbbegi.api.auth.dto.request.LoginRequestDto;
-import com.ddukbbegi.api.auth.dto.request.SignupRequestDto;
-import com.ddukbbegi.api.store.repository.StoreRepository;
-import com.ddukbbegi.support.config.TestContainersConfig;
-import com.ddukbbegi.support.fixture.StoreFixture;
-import io.restassured.RestAssured;
+import com.ddukbbegi.acceptance.support.AcceptanceTestSupport;
+import com.ddukbbegi.api.store.dto.request.*;
+import com.ddukbbegi.api.store.dto.response.StoreDetailResponseDto;
+import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
+import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.StoreStatus;
+import com.ddukbbegi.api.user.enums.UserRole;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("testcontainers")
-@Transactional
-public class StoreAcceptanceTest extends TestContainersConfig {
-    
-    @LocalServerPort
-    int port;
+@DisplayName("Store 인수 테스트")
+public class StoreAcceptanceTest extends AcceptanceTestSupport {
 
-    private final String email = "test@test.com";
-    private final String password = "Pwdpwdpwd1!";
+    private final String email = "owner@test.com";
 
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
-
-    @Test
-    void contextLoads() {
-        // 테스트 환경 정상 동작 하는지 확인하기 위해 사용
-    }
-
-    @DisplayName("1. 사장이 가게 등록 후 조회")
+    @DisplayName("1. (사장) 가게 등록 후 상세 조회")
     @Test
     void registerStoreAndGet() {
         // given
-        회원가입_사장();
-        String accessToken = 로그인_및_액세스_토큰_발급();
+        String accessToken = 회원가입하고_로그인("owner1@test.com", UserRole.OWNER);
 
         // when
-        Long storeId = 사장_가게_등록(accessToken);
+        Long storeId = 사장_가게등록(accessToken);
 
         // then
-        사장가게상세_조회_검증(accessToken, storeId, "맛있는김밥");
+        사장_가게상세_조회_검증(accessToken, storeId, "맛있는김밥");
     }
 
-    private void 회원가입_사장() {
+
+    @DisplayName("2. (사장) 등록된 가게 기본 정보 및 상태 수정")
+    @Test
+    void updateStoreInfo() {
+        // given
+        String accessToken = 회원가입하고_로그인("owner2@test.com", UserRole.OWNER);
+        Long storeId = 사장_가게등록(accessToken);
+
+        // when
+        가게_기본정보_수정(accessToken, storeId);
+        가게_임시영업중지_수정(accessToken, storeId);
+        
+        // then
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        assertThat(store.getName()).isEqualTo("더 맛있는김밥");
+        assertThat(store.getStatus()).isEqualTo(StoreStatus.TEMPORARILY_CLOSED);
+    }
+
+    @DisplayName("3. (유저) 가게 목록 조회 및 가게 상세 정보 조회")
+    @Test
+    void getStoreListAndDetails() {
+        // given
+        String ownerAccessToken = 회원가입하고_로그인("owner3@test.com", UserRole.OWNER);
+        사장_가게등록(ownerAccessToken);
+        사장_가게등록(ownerAccessToken);
+        사장_가게등록(ownerAccessToken);
+
+        String userAccessToken = 회원가입하고_로그인("user@test.com", UserRole.USER);
+
+        // when
+        List<StorePageItemResponseDto> responseDtoList = 고객_가게목록_조회(userAccessToken, "김밥");
+        Long storeId = responseDtoList.get(0).storeId();
+        StoreDetailResponseDto detailDto = 고객_가게상세_조회(userAccessToken, storeId);
+
+        // then
+        assertThat(responseDtoList.size()).isEqualTo(3);
+        assertThat(detailDto.storeId()).isEqualTo(storeId);
+        assertThat(detailDto.basicInfo().name()).isEqualTo("맛있는김밥");
+    }
+
+
+    private void 사장_가게상세_조회_검증(String accessToken, Long storeId, String expectedName) {
         given()
-                .contentType(ContentType.JSON)
-                .body(new SignupRequestDto(email, password, "test", "010-1234-5678", "OWNER"))
-                .when()
-                .post("/api/auth/signup")
-                .then()
-                .statusCode(200);
-    }
-
-    private String 로그인_및_액세스_토큰_발급() {
-        return given()
-                .contentType(ContentType.JSON)
-                .body(new LoginRequestDto(email, password))
-                .when()
-                .post("/api/auth/login")
-                .then()
-                .statusCode(200)
-                .extract()
-                .path("data.accessToken");
-    }
-
-    private Long 사장_가게_등록(String accessToken) {
-        return given()
                 .header("Authorization", accessToken)
-                .contentType(ContentType.JSON)
-                .body(StoreFixture.createStoreRegisterRequestDto())
-                .when()
-                .post("/api/owner/stores")
-                .then()
-                .statusCode(200)
-                .extract()
-                .jsonPath()
-                .getLong("data.storeId");
-    }
-    
-    private void 사장가게상세_조회_검증(String accessToken, Long storeId, String expectedName) {
-        given()
-                .header("Authorization", accessToken)
+            .when()
                 .get("/api/owner/stores/{storeId}", storeId)
-                .then()
+            .then()
                 .statusCode(200)
                 .body("data.basicInfo.name", equalTo(expectedName));
     }
 
-    private void 사장_가게_정보_수정(String accessToken, Long storeId) {
+    private void 가게_기본정보_수정(String accessToken, Long storeId) {
+        RequestStoreBasicInfo requestStoreBasicInfo = new RequestStoreBasicInfo(
+                "더 맛있는김밥",
+                "양식",
+                "010-1234-5678",
+                "신선한 재료로 매일 준비합니다."
+        );
+        StoreUpdateBasicInfoRequestDto dto = new StoreUpdateBasicInfoRequestDto(requestStoreBasicInfo);
 
+        given()
+                .header("Authorization", accessToken)
+                .contentType(ContentType.JSON)
+                .body(dto)
+            .when()
+                .patch("/api/owner/stores/{storeId}/basic-info", storeId)
+            .then()
+                .statusCode(200);
+    }
+
+    private void 가게_임시영업중지_수정(String accessToken, Long storeId) {
+        given()
+                .header("Authorization", accessToken)
+                .contentType(ContentType.JSON)
+                .body(new StoreUpdateStatusRequest(true))
+            .when()
+                .patch("/api/owner/stores/{storeId}/temporarily-close", storeId)
+            .then()
+                .statusCode(200);
+    }
+
+    private List<StorePageItemResponseDto> 고객_가게목록_조회(String accessToken, String name) {
+        return given()
+                .header("Authorization", accessToken)
+                .queryParam("name", name)
+            .when()
+                .get("/api/stores")
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getList("data.data", StorePageItemResponseDto.class);
+    }
+
+    private StoreDetailResponseDto 고객_가게상세_조회(String accessToken, Long storeId) {
+        return given()
+                .header("Authorization", accessToken)
+            .when()
+                .get("/api/stores/{storeId}", storeId)
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getObject("data", StoreDetailResponseDto.class);
     }
 
 }

--- a/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
@@ -5,6 +5,7 @@ import com.ddukbbegi.api.store.dto.request.*;
 import com.ddukbbegi.api.store.dto.response.StoreDetailResponseDto;
 import com.ddukbbegi.api.store.dto.response.StorePageItemResponseDto;
 import com.ddukbbegi.api.store.entity.Store;
+import com.ddukbbegi.api.store.enums.DayOfWeek;
 import com.ddukbbegi.api.store.enums.StoreStatus;
 import com.ddukbbegi.api.user.enums.UserRole;
 import io.restassured.http.ContentType;
@@ -22,7 +23,7 @@ public class StoreAcceptanceTest extends AcceptanceTestSupport {
 
     private final String email = "owner@test.com";
 
-    @DisplayName("1. (사장) 가게 등록 후 상세 조회")
+    @DisplayName("1. (사장) 가게를 등록한 후 등록한 가게의 상세 정보를 조회한다.")
     @Test
     void registerStoreAndGet() {
         // given
@@ -33,9 +34,13 @@ public class StoreAcceptanceTest extends AcceptanceTestSupport {
 
         // then
         사장_가게상세_조회_검증(storeId, "맛있는김밥");
+
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        assertThat(store.getName()).isEqualTo("맛있는김밥");
+        assertThat(store.getClosedDays()).isEqualTo(List.of(DayOfWeek.MON, DayOfWeek.SUN));
     }
 
-    @DisplayName("2. (사장) 등록된 가게 기본 정보 및 상태 수정")
+    @DisplayName("2. (사장) 등록된 가게 기본 정보와 영업 상태 수정를 수정한다.")
     @Test
     void updateStoreInfo() {
         // given
@@ -52,7 +57,7 @@ public class StoreAcceptanceTest extends AcceptanceTestSupport {
         assertThat(store.getStatus()).isEqualTo(StoreStatus.TEMPORARILY_CLOSED);
     }
 
-    @DisplayName("3. (유저) 가게 목록 조회 및 가게 상세 정보 조회")
+    @DisplayName("3. (유저) 키워드로 가게를 검색하고 원하는 가게의 상세 정보를 조회한다.")
     @Test
     void getStoreListAndDetails() {
         // given

--- a/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
+++ b/src/test/java/com/ddukbbegi/acceptance/StoreAcceptanceTest.java
@@ -17,7 +17,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-@DisplayName("Store 인수 테스트")
+@DisplayName("인수 테스트 - Store")
 public class StoreAcceptanceTest extends AcceptanceTestSupport {
 
     private final String email = "owner@test.com";

--- a/src/test/java/com/ddukbbegi/acceptance/support/AcceptanceTestSupport.java
+++ b/src/test/java/com/ddukbbegi/acceptance/support/AcceptanceTestSupport.java
@@ -1,0 +1,86 @@
+package com.ddukbbegi.acceptance.support;
+
+import com.ddukbbegi.api.auth.dto.request.LoginRequestDto;
+import com.ddukbbegi.api.auth.dto.request.SignupRequestDto;
+import com.ddukbbegi.api.store.repository.StoreRepository;
+import com.ddukbbegi.api.user.enums.UserRole;
+import com.ddukbbegi.api.user.repository.UserRepository;
+import com.ddukbbegi.support.fixture.StoreFixture;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static io.restassured.RestAssured.given;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Transactional
+public abstract class AcceptanceTestSupport {//extends TestContainersConfig {
+
+    @Autowired
+    protected StoreRepository storeRepository;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @LocalServerPort
+    protected int port;
+
+    @BeforeEach
+    void deleteAll() {
+        storeRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @BeforeEach
+    void setUpRestAssuredPort() {
+        RestAssured.port = port;
+    }
+
+    protected String 회원가입하고_로그인(String email, UserRole userRole) {
+        회원가입(email, userRole);
+        return 로그인_및_액세스_토큰_발급(email, userRole);
+    }
+
+    protected void 회원가입(String email, UserRole userRole) {
+        given()
+                .contentType(ContentType.JSON)
+                .body(new SignupRequestDto(email, "Pwdpwdpwd1!", "test", "010-1234-5678", userRole.name()))
+            .when()
+                .post("/api/auth/signup")
+            .then()
+                .statusCode(200);
+    }
+
+    protected String 로그인_및_액세스_토큰_발급(String email, UserRole userRole) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(new LoginRequestDto(email, "Pwdpwdpwd1!"))
+            .when()
+                .post("/api/auth/login")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("data.accessToken");
+    }
+
+    protected Long 사장_가게등록(String accessToken) {
+        return given()
+                .header("Authorization", accessToken)
+                .contentType(ContentType.JSON)
+                .body(StoreFixture.createStoreRegisterRequestDto())
+            .when()
+                .post("/api/owner/stores")
+            .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getLong("data.storeId");
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/acceptance/support/AcceptanceTestSupport.java
+++ b/src/test/java/com/ddukbbegi/acceptance/support/AcceptanceTestSupport.java
@@ -4,6 +4,7 @@ import com.ddukbbegi.api.auth.dto.request.LoginRequestDto;
 import com.ddukbbegi.api.auth.dto.request.SignupRequestDto;
 import com.ddukbbegi.api.menu.repository.MenuRepository;
 import com.ddukbbegi.api.order.repository.OrderRepository;
+import com.ddukbbegi.api.review.repository.ReviewRepository;
 import com.ddukbbegi.api.store.repository.StoreRepository;
 import com.ddukbbegi.api.user.enums.UserRole;
 import com.ddukbbegi.api.user.repository.UserRepository;
@@ -34,6 +35,7 @@ public abstract class AcceptanceTestSupport {//extends TestContainersConfig {
     @Autowired protected StoreRepository storeRepository;
     @Autowired protected MenuRepository menuRepository;
     @Autowired protected OrderRepository orderRepository;
+    @Autowired protected ReviewRepository reviewRepository;
 
     @Autowired private JdbcTemplate jdbcTemplate;
 
@@ -54,6 +56,7 @@ public abstract class AcceptanceTestSupport {//extends TestContainersConfig {
         jdbcTemplate.execute("DELETE FROM orders_menus");
 
         // 2) 엔티티 테이블 삭제 (참조 관계 역순)
+        reviewRepository.deleteAll();
         orderRepository.deleteAll();
         menuRepository.deleteAll();
         storeRepository.deleteAll();
@@ -151,6 +154,17 @@ public abstract class AcceptanceTestSupport {//extends TestContainersConfig {
                 .extract()
                 .jsonPath()
                 .getLong("data.id");
+    }
+
+    protected void 사장_주문수락(Long orderId) {
+        given()
+                .header("Authorization", ownerAccessToken)
+                .contentType(ContentType.JSON)
+                .queryParam("status", "ACCEPTED")
+                .when()
+                .patch("/api/owner/orders/{orderId}", orderId)
+                .then()
+                .statusCode(200);
     }
 
 }

--- a/src/test/java/com/ddukbbegi/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/review/service/ReviewServiceTest.java
@@ -1,6 +1,7 @@
 package com.ddukbbegi.api.review.service;
 
 import com.ddukbbegi.api.order.entity.Order;
+import com.ddukbbegi.api.order.enums.OrderStatus;
 import com.ddukbbegi.api.order.repository.OrderRepository;
 import com.ddukbbegi.api.review.dto.*;
 import com.ddukbbegi.api.review.entity.Review;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,7 +52,7 @@ class ReviewServiceTest {
 
     @Test
     void saveReview() {
-        Order order = Order.builder().build();
+        Order order = mock(Order.class);
         User user = new User();
         Long likeCount = 0L;
         ReviewRequestDto requestDto =
@@ -74,6 +76,7 @@ class ReviewServiceTest {
                 .willReturn(order);
         given(userRepository.findByIdOrElseThrow(userId))
                 .willReturn(user);
+        given(order.getOrderStatus()).willReturn(OrderStatus.DELIVERED);
         // 여기서 Review.from()은 stub하지 않고 그냥 사용
 
         given(reviewRepository.save(any(Review.class)))

--- a/src/test/java/com/ddukbbegi/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/store/service/StoreServiceTest.java
@@ -60,6 +60,7 @@ class StoreServiceTest {
             given(storeRepository.isStoreRegistrationAvailable(userId)).willReturn(true);
             given(userRepository.findByIdOrElseThrow(userId)).willReturn(user);
             given(storeRepository.save(any(Store.class))).willReturn(store);
+            given(storeStatusResolveService.resolveStoreStatus(any(Store.class), any(LocalDateTime.class))).willReturn(StoreStatus.OPEN);
 
             // when
             StoreIdResponseDto storeIdResponseDto = storeService.registerStore(dto, userId);

--- a/src/test/java/com/ddukbbegi/api/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ddukbbegi/api/store/service/StoreServiceTest.java
@@ -23,8 +23,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -35,6 +37,8 @@ import static org.mockito.Mockito.mock;
 class StoreServiceTest {
 
     @InjectMocks private StoreService storeService;
+
+    @Mock private StoreStatusResolveService storeStatusResolveService;
 
     @Mock private StoreRepository storeRepository;
     @Mock private UserRepository userRepository;
@@ -62,6 +66,7 @@ class StoreServiceTest {
 
             // then
             assertThat(storeIdResponseDto.storeId()).isEqualTo(1L);
+            
         }
 
         @DisplayName("실패 - 이미 등록된 가게가 3개 이상일 경우 예외 발생")
@@ -274,6 +279,7 @@ class StoreServiceTest {
             given(storeRepository.findByIdOrElseThrow(storeId)).willReturn(store);
             given(user.getId()).willReturn(userId);
             given(storeRepository.isStoreRegistrationAvailable(userId)).willReturn(true);
+            given(storeStatusResolveService.resolveStoreStatus(any(Store.class), any(LocalDateTime.class))).willReturn(StoreStatus.OPEN);
 
             // when
             storeService.updatePermanentlyClosed(storeId, dto, userId);

--- a/src/test/java/com/ddukbbegi/support/config/TestContainersConfig.java
+++ b/src/test/java/com/ddukbbegi/support/config/TestContainersConfig.java
@@ -1,0 +1,37 @@
+package com.ddukbbegi.support.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class TestContainersConfig {
+
+    @Container
+    protected static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("test-db")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    protected static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>("redis:7.2")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        // MySql 설정
+        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL_CONTAINER::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+
+        // Redis 설정
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(6379));
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/support/config/TestContainersConfig.java
+++ b/src/test/java/com/ddukbbegi/support/config/TestContainersConfig.java
@@ -1,35 +1,39 @@
 package com.ddukbbegi.support.config;
 
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
+//@Testcontainers
+@ActiveProfiles("testcontainers")
 public abstract class TestContainersConfig {
 
-    @Container
-    protected static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
-            .withDatabaseName("test-db")
-            .withUsername("test")
-            .withPassword("test");
+    // --- 1) 싱글톤 컨테이너 선언 및 수동 시작 ---
+    private static final MySQLContainer<?> MYSQL_CONTAINER;
+    private static final GenericContainer<?> REDIS_CONTAINER;
 
-    @Container
-    protected static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>("redis:7.2")
-            .withExposedPorts(6379);
+    static {
+        MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
+                .withDatabaseName("test-db")
+                .withUsername("test")
+                .withPassword("test");
+        MYSQL_CONTAINER.start();
 
+        REDIS_CONTAINER = new GenericContainer<>("redis:7.2")
+                .withExposedPorts(6379);
+        REDIS_CONTAINER.start();
+    }
+
+    // --- 2) Spring 프로퍼티 오버라이드 ---
     @DynamicPropertySource
     static void overrideProps(DynamicPropertyRegistry registry) {
-        // MySql 설정
         registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
         registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
         registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
         registry.add("spring.datasource.driver-class-name", MYSQL_CONTAINER::getDriverClassName);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
-
-        // Redis 설정
         registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
         registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(6379));
     }

--- a/src/test/java/com/ddukbbegi/support/fixture/MenuFixture.java
+++ b/src/test/java/com/ddukbbegi/support/fixture/MenuFixture.java
@@ -1,0 +1,19 @@
+package com.ddukbbegi.support.fixture;
+
+import com.ddukbbegi.api.menu.dto.request.NewMenuRequestDto;
+import com.ddukbbegi.api.menu.enums.Category;
+import com.ddukbbegi.api.menu.enums.MenuStatus;
+
+public class MenuFixture {
+
+    public static NewMenuRequestDto createNewMenuRequestDto(String menuName) {
+        return new NewMenuRequestDto(
+                menuName,
+                1000,
+                "description",
+                Category.MAIN_MENU,
+                MenuStatus.ON_SALE
+        );
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/support/fixture/MenuFixture.java
+++ b/src/test/java/com/ddukbbegi/support/fixture/MenuFixture.java
@@ -9,7 +9,7 @@ public class MenuFixture {
     public static NewMenuRequestDto createNewMenuRequestDto(String menuName) {
         return new NewMenuRequestDto(
                 menuName,
-                1000,
+                10000,
                 "description",
                 Category.MAIN_MENU,
                 MenuStatus.ON_SALE

--- a/src/test/java/com/ddukbbegi/support/fixture/OrderFixture.java
+++ b/src/test/java/com/ddukbbegi/support/fixture/OrderFixture.java
@@ -1,0 +1,29 @@
+package com.ddukbbegi.support.fixture;
+
+import com.ddukbbegi.api.order.dto.request.OrderCreateRequestDto;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+public class OrderFixture {
+
+    public static OrderCreateRequestDto createOrderCreateRequestDto(List<Long> menuIds) {
+        // menuId 당 1~5 랜덤 수량 생성
+        List<OrderCreateRequestDto.MenuOrderDto> menus = menuIds.stream()
+                .map(id -> new OrderCreateRequestDto.MenuOrderDto(
+                        id,
+                        ThreadLocalRandom.current().nextInt(1, 6)    // 1 이상 6 미만 → 1~5
+                ))
+                .toList();
+
+        return new OrderCreateRequestDto(
+                menus,
+                "문 앞에 놔주세요",
+                UUID.randomUUID().toString(),
+                false
+        );
+    }
+
+}

--- a/src/test/java/com/ddukbbegi/support/fixture/ReviewFixture.java
+++ b/src/test/java/com/ddukbbegi/support/fixture/ReviewFixture.java
@@ -1,0 +1,15 @@
+package com.ddukbbegi.support.fixture;
+
+import com.ddukbbegi.api.review.dto.AnonymousStatus;
+import com.ddukbbegi.api.review.dto.ReviewRequestDto;
+
+public class ReviewFixture {
+
+    public static ReviewRequestDto createReviewRequestDto(Long orderId, String contents) {
+        return new ReviewRequestDto(
+                orderId,
+                contents,
+                4.5f,
+                AnonymousStatus.ANONYMOUS);
+    }
+}

--- a/src/test/java/com/ddukbbegi/support/fixture/StoreFixture.java
+++ b/src/test/java/com/ddukbbegi/support/fixture/StoreFixture.java
@@ -15,18 +15,26 @@ import com.ddukbbegi.api.user.enums.UserRole;
 public class StoreFixture {
 
     public static Store createStore(User user) {
-        StoreRegisterRequestDto dto = new StoreRegisterRequestDto(
+        return new StoreRegisterRequestDto(
                 createBasicInfo(),
                 createOperationInfo(),
                 createOrderSettings()
-        );
-        return dto.toEntity(user);
+        ).toEntity(user);
     }
 
     public static StoreRegisterRequestDto createStoreRegisterRequestDto() {
         return new StoreRegisterRequestDto(
                 createBasicInfo(),
                 createOperationInfo(),
+                createOrderSettings()
+        );
+
+    }
+    // 연중무휴 24시간 운영하는 가게. 항상 OPEN인 상태를 유지함
+    public static StoreRegisterRequestDto create24StoreRegisterRequestDto() {
+        return new StoreRegisterRequestDto(
+                createBasicInfo(),
+                create24OperationInfo(),
                 createOrderSettings()
         );
     }
@@ -60,9 +68,19 @@ public class StoreFixture {
         );
     }
 
+    public static RequestStoreOperationInfo create24OperationInfo() {
+        return new RequestStoreOperationInfo(
+                "",
+                "00:00-00:00",
+                "00:00-00:00",
+                "00:00-00:00",
+                "00:00-00:00"
+        );
+    }
+
     public static RequestStoreOrderSettings createOrderSettings() {
         return new RequestStoreOrderSettings(
-                15000,
+                10000,
                 3000
         );
     }

--- a/src/test/resources/application-testcontainers.yml
+++ b/src/test/resources/application-testcontainers.yml
@@ -1,0 +1,11 @@
+spring:
+    datasource:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+    jpa:
+        hibernate:
+            ddl-auto: create
+        show-sql: true
+        
+jwt:
+    secret:
+        key: ry0zFKeOas8RVd8CmmmDytMCgj4Xp7Qm8kVOh2SmV+k=

--- a/src/test/resources/application-testcontainers.yml
+++ b/src/test/resources/application-testcontainers.yml
@@ -1,11 +1,3 @@
-spring:
-    datasource:
-        driver-class-name: com.mysql.cj.jdbc.Driver
-    jpa:
-        hibernate:
-            ddl-auto: create
-        show-sql: true
-        
 jwt:
     secret:
         key: ry0zFKeOas8RVd8CmmmDytMCgj4Xp7Qm8kVOh2SmV+k=


### PR DESCRIPTION
## 🔎 작업 내용

- 각 도메인마다 테스트 시나리오를 작성하고, 이를 인수 테스트 코드로 구현했다.
- 테스트 컨테이너를 적용했다.
- 비즈니스 로직 버그 수정 및 예외 처리 추가
  - `AllMenuResponseDto` menuId 필드 추가
  - `checkStoreIsWorking` 메서드 로직 수정
  - 주문이 완료된 상태(DELIVERED)에서만 리뷰를 작성할 수 있도록 예외처리 추가

![image](https://github.com/user-attachments/assets/974a0189-d6cd-46a8-9854-7d880d65989d)

## ➕ 트러블 슈팅

- TestContainers 적용 시 DB 연결 에러 발생 / 첫 번째 테스트 클래스는 성공하나 그 이후는 연결 에러 발생
  - @Testcontainers 와 @Container를 사용해 싱글톤으로 동작하도록 구성했다.
  - 그러나 이들은 컨테이너 수명 주기를 관리하는 데 사용되기 때문에 각 테스트 클래스가 끝날 때 컨테이너가 중지된다. 
  - 이후 테스트는 이전에 구성된 Spring Context를 재사용하여 중지된 컨테이너에 연결을 시도하므로 테스트가 실패하게 된 것이다.

## 🔧 해결해야할 문제

- 주문 테스트 코드 실패
  - 주문 시 가게가 현재 영업 중인지 검사하는 메서드의 로직을 수정했다.
  - 직접 계산하는 것이 아닌 주기적으로 업데이트 되는 store의 status 칼럼을 사용하도록 했다.
  - 해당 부분 수정 이후 2개의 테스트 케이스가 실패함

This closes #84 